### PR TITLE
fix(auth0-fastify-api): Use 401 instead of 400 when no access token provided

### DIFF
--- a/packages/auth0-fastify-api/src/index.spec.ts
+++ b/packages/auth0-fastify-api/src/index.spec.ts
@@ -53,7 +53,7 @@ afterEach(() => {
   server.resetHandlers();
 });
 
-test('should return 400 when no token', async () => {
+test('should return 401 when no token', async () => {
   const fastify = Fastify();
   fastify.register(fastifyAuth0Api, {
     domain: domain,
@@ -77,7 +77,7 @@ test('should return 400 when no token', async () => {
     url: '/test',
   });
 
-  expect(res.statusCode).toBe(400);
+  expect(res.statusCode).toBe(401);
   expect(res.json().error).toBe('invalid_request');
   expect(res.json().error_description).toBe('No Authorization provided');
 });

--- a/packages/auth0-fastify-api/src/index.ts
+++ b/packages/auth0-fastify-api/src/index.ts
@@ -83,7 +83,7 @@ async function auth0FastifApi(fastify: FastifyInstance, options: Auth0FastifyApi
       const accessToken = getToken(request);
 
       if (!accessToken) {
-        return replyWithError(reply, 400, 'invalid_request', 'No Authorization provided');
+        return replyWithError(reply, 401, 'invalid_request', 'No Authorization provided');
       }
 
       try {


### PR DESCRIPTION
We want to return as 401, instead of a 400 in the case where the request has no authorization header.