### PR TITLE
fix: support older entry points

### DIFF
--- a/packages/auth0-fastify-api/package.json
+++ b/packages/auth0-fastify-api/package.json
@@ -13,6 +13,9 @@
     "test": "vitest run",
     "test:ci": "vitest --watch false --coverage"
   },
+  "types": "./dist/index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/auth0-fastify/package.json
+++ b/packages/auth0-fastify/package.json
@@ -13,6 +13,9 @@
     "test": "vitest run",
     "test:ci": "vitest --watch false --coverage"
   },
+  "types": "./dist/index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
Fixes #12

Not all tools support the new `exports` declaration yet.

Older versions of TypesScript (5.2+) do not consider it.
WebStorm does not either, at least when using Yarn PnP.

It is easy to keep this support, and the newer tools still give precedence to `exports`.

Thank you for your consideration!