### PR TITLE
fix(auth0-fastify-api): correctly mark iss, sub, and aud claims as required

### DIFF
--- a/packages/auth0-fastify-api/src/index.ts
+++ b/packages/auth0-fastify-api/src/index.ts
@@ -35,9 +35,9 @@ export interface Auth0FastifyApiOptions {
 }
 
 export interface Token {
-  sub?: string;
-  aud?: string | string[];
-  iss?: string;
+  sub: string;
+  aud: string | string[];
+  iss: string;
   scope?: string;
 }
 
@@ -87,7 +87,8 @@ async function auth0FastifApi(fastify: FastifyInstance, options: Auth0FastifyApi
       }
 
       try {
-        const token: Token = await apiClient.verifyAccessToken({ accessToken });
+        const token = await apiClient.verifyAccessToken({ accessToken }) as Token;
+
         if (opts.scopes && !validateScopes(token, opts.scopes)) {
           return replyWithError(reply, 403, 'insufficient_scope', 'Insufficient scopes');
         }


### PR DESCRIPTION
As per https://datatracker.ietf.org/doc/rfc9068/, `sub`, `iss` and `aud` are required claims in OAuth 2.0.

Closes #20