### PR TITLE
feat(auth0-fastify-api): decorate fastify instance with auth0Client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,11 +61,12 @@
       }
     },
     "node_modules/@auth0/auth0-api-js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@auth0/auth0-api-js/-/auth0-api-js-1.0.0.tgz",
-      "integrity": "sha512-bIkqgptN7KUuIL90ANFXZYoP1OvFmrOodEGh2ECSoBOaNdBPuq0jSP717m5a1ve872lvrhorY0BymHMncR26hA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-api-js/-/auth0-api-js-1.1.0.tgz",
+      "integrity": "sha512-i7NDLyDlOkxC9QEXHVxxQt3KoUdKlRfijsa/eitsAVFnQNOYuWhBNtGDYMSQ5enWnTtyMPOCAXUOCLfoLB07Eg==",
       "license": "MIT",
       "dependencies": {
+        "@auth0/auth0-auth-js": "^1.1.0",
         "jose": "^6.0.8",
         "oauth4webapi": "^3.3.0"
       }
@@ -5873,7 +5874,7 @@
       "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
-        "@auth0/auth0-api-js": "^1.0.0",
+        "@auth0/auth0-api-js": "^1.1.0",
         "fastify": "^5.3.2",
         "fastify-plugin": "^5.0.1"
       },

--- a/packages/auth0-fastify-api/EXAMPLES.md
+++ b/packages/auth0-fastify-api/EXAMPLES.md
@@ -46,6 +46,12 @@ fastify.register(fastifyAuth0, {
 });
 ```
 
+## The `ApiClient` instance
+
+Once the plugin is registered, an instance of the Auth0 `ApiClient` is available via `fastify.auth0Client`. This instance can be used to call any of the methods available on the `ApiClient`, such as `verifyAccessToken()` and `getAccessTokenForConnection()`.
+
+For the complete list of available methods, please refer to the [@auth0/auth0-api-js SDK documentation](https://github.com/auth0/auth0-auth-js/blob/main/packages/auth0-api-js/README.md).
+
 ## Protecting API Routes
 
 In order to protect an API route, you can use the SDK's `requireAuth()` method in a preHandler:

--- a/packages/auth0-fastify-api/package.json
+++ b/packages/auth0-fastify-api/package.json
@@ -33,7 +33,7 @@
     "vitest": "^3.0.5"
   },
   "dependencies": {
-    "@auth0/auth0-api-js": "^1.0.0",
+    "@auth0/auth0-api-js": "^1.1.0",
     "fastify": "^5.3.2",
     "fastify-plugin": "^5.0.1"
   },
@@ -44,14 +44,14 @@
     "access": "public"
   },
   "repository": {
-      "type": "git",
-      "url": "git://github.com/auth0/auth0-fastify.git"
+    "type": "git",
+    "url": "git://github.com/auth0/auth0-fastify.git"
   },
   "bugs": {
-      "url": "https://github.com/auth0/auth0-fastify/issues"
+    "url": "https://github.com/auth0/auth0-fastify/issues"
   },
   "homepage": "https://github.com/auth0/auth0-fastify#readme",
   "keywords": [
-      "auth0"
+    "auth0"
   ]
 }


### PR DESCRIPTION
### Description

- Bumps the `@auth0/auth0-api-js` dependency version to the latest release: https://github.com/auth0/auth0-auth-js/releases/tag/auth0-api-js-v1.1.0
- Decorates the `fastify` instance with the `auth0Client` to access the `ApiClient` instance

### References

- https://github.com/auth0/auth0-auth-js/releases/tag/auth0-api-js-v1.1.0

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
