### PR TITLE
Release fix fastify-api v1.1.0

### DIFF
--- a/.github/actions/get-release-notes/action.yml
+++ b/.github/actions/get-release-notes/action.yml
@@ -31,7 +31,7 @@ runs:
             state: 'all',
             head: `${process.env.REPO_OWNER}:release/${process.env.PACKAGE}-${process.env.VERSION}`,
           });
-          core.setOutput('RELEASE_NOTES', pulls[0].body);
+          core.setOutput('RELEASE_NOTES', pulls[0]?.body || '');
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
         REPO_OWNER: ${{ inputs.repo_owner }}


### PR DESCRIPTION
### Description

Fix release from forks when attempting to read the PR body for changelog.

This will create a new release without release notes — please be sure to populate it manually.