### PR TITLE
fix(auth0-fastify): make request and reply more abstract so that it can be used with http2

### DIFF
--- a/examples/example-fastify-web/src/index.ts
+++ b/examples/example-fastify-web/src/index.ts
@@ -1,4 +1,4 @@
-import Fastify, { FastifyReply, FastifyRequest, RouteGenericInterface } from 'fastify';
+import Fastify, { FastifyReply, FastifyRequest } from 'fastify';
 import fastifyStatic from '@fastify/static';
 import fastifyView from '@fastify/view';
 import fastifyAuth0 from '@auth0/auth0-fastify';
@@ -6,19 +6,9 @@ import ejs from 'ejs';
 import 'dotenv/config';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { readFileSync } from 'node:fs';
-import { Http2SecureServer, Http2ServerRequest, Http2ServerResponse } from 'node:http2';
 
 const fastify = Fastify({
   logger: true,
-  http2: true,
-
-  // Use `mkcert localhost 127.0.0.1 ::1` in the `examples/example-fastify-web` directory to generate these files
-  https: {
-    allowHTTP1: true,
-    key: readFileSync('./localhost+2-key.pem'),
-    cert: readFileSync('./localhost+2.pem')
-  }
 });
 
 // Fix to use __dirname in ES modules
@@ -53,8 +43,8 @@ fastify.get('/', async (request, reply) => {
 });
 
 async function hasSessionPreHandler(
-  request: FastifyRequest<RouteGenericInterface, Http2SecureServer, Http2ServerRequest>,
-  reply: FastifyReply<RouteGenericInterface, Http2SecureServer, Http2ServerRequest, Http2ServerResponse<Http2ServerRequest>>
+  request: FastifyRequest,
+  reply: FastifyReply
 ) {
   const session = await fastify.auth0Client!.getSession({ request, reply });
 

--- a/examples/example-fastify-web/src/index.ts
+++ b/examples/example-fastify-web/src/index.ts
@@ -1,4 +1,4 @@
-import Fastify, { FastifyReply, FastifyRequest } from 'fastify';
+import Fastify, { FastifyReply, FastifyRequest, RouteGenericInterface } from 'fastify';
 import fastifyStatic from '@fastify/static';
 import fastifyView from '@fastify/view';
 import fastifyAuth0 from '@auth0/auth0-fastify';
@@ -6,9 +6,19 @@ import ejs from 'ejs';
 import 'dotenv/config';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { readFileSync } from 'node:fs';
+import { Http2SecureServer, Http2ServerRequest, Http2ServerResponse } from 'node:http2';
 
 const fastify = Fastify({
   logger: true,
+  http2: true,
+
+  // Use `mkcert localhost 127.0.0.1 ::1` in the `examples/example-fastify-web` directory to generate these files
+  https: {
+    allowHTTP1: true,
+    key: readFileSync('./localhost+2-key.pem'),
+    cert: readFileSync('./localhost+2.pem')
+  }
 });
 
 // Fix to use __dirname in ES modules
@@ -43,8 +53,8 @@ fastify.get('/', async (request, reply) => {
 });
 
 async function hasSessionPreHandler(
-  request: FastifyRequest,
-  reply: FastifyReply
+  request: FastifyRequest<RouteGenericInterface, Http2SecureServer, Http2ServerRequest>,
+  reply: FastifyReply<RouteGenericInterface, Http2SecureServer, Http2ServerRequest, Http2ServerResponse<Http2ServerRequest>>
 ) {
   const session = await fastify.auth0Client!.getSession({ request, reply });
 

--- a/packages/auth0-fastify/src/index.ts
+++ b/packages/auth0-fastify/src/index.ts
@@ -16,11 +16,24 @@ export * from './types.js';
 export { CookieTransactionStore } from '@auth0/auth0-server-js';
 
 declare module 'fastify' {
+  /**
+   * FastifyInstance is a generic interface, whose generics represent the underlying server, request and reply types.
+   * By extending the interface with the same generics, we ensure that the `auth0Client` property is aware
+   * of the underlying server type (e.g., HTTP/1.1, HTTP/2, etc.).
+   *
+   * @remark The generics default to the values used by a standard Fastify instance.
+   */
   interface FastifyInstance<
     RawServer extends RawServerBase = RawServerDefault,
     RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
     RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>
   > {
+    /**
+     * The Auth0 Server Client instance attached to the Fastify instance.
+     * This client is used to interact with Auth0 for authentication and session management.
+     *
+     * We pass-through the FastifyInstance generics to ensure compatibility with different server types.
+     */
     auth0Client: ServerClient<StoreOptions<RawServer, RawRequest, RawReply>> | undefined;
   }
 }

--- a/packages/auth0-fastify/src/index.ts
+++ b/packages/auth0-fastify/src/index.ts
@@ -1,4 +1,11 @@
-import type { FastifyInstance, FastifyRequest } from 'fastify';
+import type {
+  FastifyInstance,
+  FastifyRequest,
+  RawServerBase,
+  RawRequestDefaultExpression,
+  RawReplyDefaultExpression,
+  RawServerDefault,
+} from 'fastify';
 import fp from 'fastify-plugin';
 import { CookieTransactionStore, ServerClient, StatelessStateStore, StatefulStateStore } from '@auth0/auth0-server-js';
 import type { SessionConfiguration, SessionStore, StoreOptions } from './types.js';
@@ -9,12 +16,20 @@ export * from './types.js';
 export { CookieTransactionStore } from '@auth0/auth0-server-js';
 
 declare module 'fastify' {
-  interface FastifyInstance {
-    auth0Client: ServerClient<StoreOptions> | undefined;
+  interface FastifyInstance<
+    RawServer extends RawServerBase = RawServerDefault,
+    RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
+    RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>
+  > {
+    auth0Client: ServerClient<StoreOptions<RawServer, RawRequest, RawReply>> | undefined;
   }
 }
 
-export interface Auth0FastifyOptions {
+export interface Auth0FastifyOptions<
+  RawServer extends RawServerBase = RawServerDefault,
+  RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
+  RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>
+> {
   domain: string;
   clientId: string;
   clientSecret?: string;
@@ -26,7 +41,7 @@ export interface Auth0FastifyOptions {
   pushedAuthorizationRequests?: boolean;
 
   sessionSecret: string;
-  sessionStore?: SessionStore;
+  sessionStore?: SessionStore<RawServer, RawRequest, RawReply>;
   sessionConfiguration?: SessionConfiguration;
   /**
    * Whether to mount the default routes for login, logout, callback and profile.
@@ -55,11 +70,18 @@ export interface Auth0FastifyOptions {
   };
 }
 
-export default fp(async function auth0Fastify(fastify: FastifyInstance, options: Auth0FastifyOptions) {
+export default fp(async function auth0Fastify<
+  RawServer extends RawServerBase = RawServerDefault,
+  RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
+  RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>
+>(
+  fastify: FastifyInstance<RawServer, RawRequest, RawReply>,
+  options: Auth0FastifyOptions<RawServer, RawRequest, RawReply>
+) {
   const callbackPath = options.routes?.callback ?? '/auth/callback';
   const redirectUri = createRouteUrl(callbackPath, options.appBaseUrl);
 
-  const auth0Client = new ServerClient<StoreOptions>({
+  const auth0Client = new ServerClient<StoreOptions<RawServer, RawRequest, RawReply>>({
     domain: options.domain,
     clientId: options.clientId,
     clientSecret: options.clientSecret,
@@ -69,7 +91,10 @@ export default fp(async function auth0Fastify(fastify: FastifyInstance, options:
       audience: options.audience,
       redirect_uri: redirectUri.toString(),
     },
-    transactionStore: new CookieTransactionStore({ secret: options.sessionSecret }, new FastifyCookieHandler()),
+    transactionStore: new CookieTransactionStore(
+      { secret: options.sessionSecret },
+      new FastifyCookieHandler<RawServer, RawRequest, RawReply>()
+    ),
     stateStore: options.sessionStore
       ? new StatefulStateStore(
           {
@@ -77,14 +102,14 @@ export default fp(async function auth0Fastify(fastify: FastifyInstance, options:
             secret: options.sessionSecret,
             store: options.sessionStore,
           },
-          new FastifyCookieHandler()
+          new FastifyCookieHandler<RawServer, RawRequest, RawReply>()
         )
       : new StatelessStateStore(
           {
             ...options.sessionConfiguration,
             secret: options.sessionSecret,
           },
-          new FastifyCookieHandler()
+          new FastifyCookieHandler<RawServer, RawRequest, RawReply>()
         ),
     stateIdentifier: options.sessionConfiguration?.cookie?.name,
     customFetch: options.customFetch,
@@ -100,9 +125,13 @@ export default fp(async function auth0Fastify(fastify: FastifyInstance, options:
     fastify.get(
       options.routes?.login ?? '/auth/login',
       async (
-        request: FastifyRequest<{
-          Querystring: { returnTo?: string };
-        }>,
+        request: FastifyRequest<
+          {
+            Querystring: { returnTo?: string };
+          },
+          RawServer,
+          RawRequest
+        >,
         reply
       ) => {
         const dangerousReturnTo = request.query.returnTo;
@@ -139,9 +168,13 @@ export default fp(async function auth0Fastify(fastify: FastifyInstance, options:
     fastify.post(
       options.routes?.backchannelLogout ?? '/auth/backchannel-logout',
       async (
-        request: FastifyRequest<{
-          Body: { logout_token?: string };
-        }>,
+        request: FastifyRequest<
+          {
+            Body: { logout_token?: string };
+          },
+          RawServer,
+          RawRequest
+        >,
         reply
       ) => {
         const logoutToken = request.body.logout_token;
@@ -167,9 +200,13 @@ export default fp(async function auth0Fastify(fastify: FastifyInstance, options:
       fastify.get(
         options.routes?.connect ?? '/auth/connect',
         async (
-          request: FastifyRequest<{
-            Querystring: { connection: string; connectionScope: string; returnTo?: string };
-          }>,
+          request: FastifyRequest<
+            {
+              Querystring: { connection: string; connectionScope: string; returnTo?: string };
+            },
+            RawServer,
+            RawRequest
+          >,
           reply
         ) => {
           const { connection, connectionScope, returnTo } = request.query;
@@ -218,9 +255,13 @@ export default fp(async function auth0Fastify(fastify: FastifyInstance, options:
       fastify.get(
         options.routes?.unconnect ?? '/auth/unconnect',
         async (
-          request: FastifyRequest<{
-            Querystring: { connection: string; returnTo?: string };
-          }>,
+          request: FastifyRequest<
+            {
+              Querystring: { connection: string; returnTo?: string };
+            },
+            RawServer,
+            RawRequest
+          >,
           reply
         ) => {
           const { connection, returnTo } = request.query;

--- a/packages/auth0-fastify/src/store/fastify-cookie-handler.ts
+++ b/packages/auth0-fastify/src/store/fastify-cookie-handler.ts
@@ -1,9 +1,20 @@
 import { CookieHandler, CookieSerializeOptions } from '@auth0/auth0-server-js';
+import type { RawServerBase, RawRequestDefaultExpression, RawReplyDefaultExpression, RawServerDefault } from 'fastify';
 import { StoreOptions } from '../types.js';
 import { MissingStoreOptionsError } from '../errors/index.js';
 
-export class FastifyCookieHandler implements CookieHandler<StoreOptions> {
-  setCookie(name: string, value: string, options?: CookieSerializeOptions, storeOptions?: StoreOptions): void {
+export class FastifyCookieHandler<
+  RawServer extends RawServerBase = RawServerDefault,
+  RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
+  RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>
+> implements CookieHandler<StoreOptions<RawServer, RawRequest, RawReply>>
+{
+  setCookie(
+    name: string,
+    value: string,
+    options?: CookieSerializeOptions,
+    storeOptions?: StoreOptions<RawServer, RawRequest, RawReply>
+  ): void {
     if (!storeOptions) {
       throw new MissingStoreOptionsError();
     }
@@ -11,7 +22,7 @@ export class FastifyCookieHandler implements CookieHandler<StoreOptions> {
     storeOptions.reply.setCookie(name, value, options || {});
   }
 
-  getCookie(name: string, storeOptions?: StoreOptions): string | undefined {
+  getCookie(name: string, storeOptions?: StoreOptions<RawServer, RawRequest, RawReply>): string | undefined {
     if (!storeOptions) {
       throw new MissingStoreOptionsError();
     }
@@ -19,7 +30,7 @@ export class FastifyCookieHandler implements CookieHandler<StoreOptions> {
     return storeOptions.request.cookies?.[name];
   }
 
-  getCookies(storeOptions?: StoreOptions): Record<string, string> {
+  getCookies(storeOptions?: StoreOptions<RawServer, RawRequest, RawReply>): Record<string, string> {
     if (!storeOptions) {
       throw new MissingStoreOptionsError();
     }
@@ -27,7 +38,7 @@ export class FastifyCookieHandler implements CookieHandler<StoreOptions> {
     return storeOptions.request.cookies as Record<string, string>;
   }
 
-  deleteCookie(name: string, storeOptions?: StoreOptions): void {
+  deleteCookie(name: string, storeOptions?: StoreOptions<RawServer, RawRequest, RawReply>): void {
     if (!storeOptions) {
       throw new MissingStoreOptionsError();
     }

--- a/packages/auth0-fastify/src/types.ts
+++ b/packages/auth0-fastify/src/types.ts
@@ -1,16 +1,35 @@
-import type { FastifyReply, FastifyRequest } from 'fastify';
+import type {
+  FastifyReply,
+  FastifyRequest,
+  RawServerBase,
+  RawRequestDefaultExpression,
+  RawReplyDefaultExpression,
+  RawServerDefault,
+  RouteGenericInterface,
+} from 'fastify';
 import { LogoutTokenClaims, StateData } from '@auth0/auth0-server-js';
 
-export interface StoreOptions {
-  request: FastifyRequest;
-  reply: FastifyReply;
+export interface StoreOptions<
+  RawServer extends RawServerBase = RawServerDefault,
+  RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
+  RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>
+> {
+  request: FastifyRequest<RouteGenericInterface, RawServer, RawRequest>;
+  reply: FastifyReply<RouteGenericInterface, RawServer, RawRequest, RawReply>;
 }
 
-export interface SessionStore {
+export interface SessionStore<
+  RawServer extends RawServerBase = RawServerDefault,
+  RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
+  RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>
+> {
   delete(identifier: string): Promise<void>;
   set(identifier: string, stateData: StateData): Promise<void>;
   get(identifier: string): Promise<StateData | undefined>;
-  deleteByLogoutToken(claims: LogoutTokenClaims, options?: StoreOptions | undefined): Promise<void>;
+  deleteByLogoutToken(
+    claims: LogoutTokenClaims,
+    options?: StoreOptions<RawServer, RawRequest, RawReply> | undefined
+  ): Promise<void>;
 }
 
 export interface SessionCookieOptions {

--- a/packages/auth0-fastify/src/types.ts
+++ b/packages/auth0-fastify/src/types.ts
@@ -9,6 +9,15 @@ import type {
 } from 'fastify';
 import { LogoutTokenClaims, StateData } from '@auth0/auth0-server-js';
 
+/**
+ * Options for accessing the Fastify request and reply objects.
+ * These are used in store implementations to interact with cookies and sessions.
+ * 
+ * FastifyInstance is a generic interface itself, whose generics represent the underlying server, request and reply types.
+ * By including these in the StoreOptions generics, we ensure that the `StoreOptions` aware of the underlying server type (e.g., HTTP/1.1, HTTP/2, etc.).
+ * 
+ * @remark The generics default to the values used by a standard Fastify instance.
+ */
 export interface StoreOptions<
   RawServer extends RawServerBase = RawServerDefault,
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,

--- a/packages/auth0-fastify/src/types.ts
+++ b/packages/auth0-fastify/src/types.ts
@@ -14,7 +14,7 @@ import { LogoutTokenClaims, StateData } from '@auth0/auth0-server-js';
  * These are used in store implementations to interact with cookies and sessions.
  * 
  * FastifyInstance is a generic interface itself, whose generics represent the underlying server, request and reply types.
- * By including these in the StoreOptions generics, we ensure that the `StoreOptions` aware of the underlying server type (e.g., HTTP/1.1, HTTP/2, etc.).
+ * By including these in the StoreOptions generics, we ensure that `StoreOptions` is aware of the underlying server type (e.g., HTTP/1.1, HTTP/2, etc.).
  * 
  * @remark The generics default to the values used by a standard Fastify instance.
  */


### PR DESCRIPTION
### Description

This PR ensures StoreOptions uses the correct FastifyRequest and FastifyReply types by plugging into the FastifyInstance generics, allowing passing `request` and `reply` when using http2.

To achieve that, we needed to pass-through the generics used by `FastifyInstance` to several places. 
In this PR, we ensured the generics all have a default value set that is compatible with a typical fastify instance, ensuring it keeps working the same as before for those not specifying any generic types yet (as some of those types aren't generic yet).

Even though the generics look complicated, and they are to some extend, the complexity remains internal for the most part, as during run-time, the types are pulled from the `FastifyInstance`, ensuring the public methods work with both http1 and http2:

**HTTP 1:**
```ts
const fastify = Fastify({
  logger: true,
});

fastify.get(
  '/private',
  {
    preHandler: hasSessionPreHandler,
  },
  // request and reply are the default implementation
  async (request, reply) => {
    // `fastify.auth0Client` knows the type for request and reply from the FastifyInstance module agumentation.
    // So `fastify.auth0ClientgetUser({ request, reply })` compiles as expected.
    const user = await fastify.auth0Client!.getUser({ request, reply }); // 

    return reply.viewAsync('public.ejs', {
      isLoggedIn: !!user,
      user,
    });
  }
);
```

**HTTP 2:**
```ts
const fastify = Fastify({
  logger: true,
  http2: true,
});

fastify.get(
  '/private',
  {
    preHandler: hasSessionPreHandler,
  },
  // Because we use http2, request and reply are now different from the default implementation
  async (request, reply) => {
    // `fastify.auth0Client` knows the type for request and reply from the FastifyInstance module agumentation.
    // So `fastify.auth0ClientgetUser({ request, reply })` compiles as expected.
    const user = await fastify.auth0Client!.getUser({ request, reply }); // 

    return reply.viewAsync('public.ejs', {
      isLoggedIn: !!user,
      user,
    });
  }
);
```

### References

#37 

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
