### PR TITLE
chore: rely on OIDC when publishing to npm

### DIFF
--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -5,8 +5,6 @@ inputs:
     required: true
   node-version:
     required: true
-  npm-token:
-    required: true
   version:
     required: true
   require-build:
@@ -50,5 +48,4 @@ runs:
         fi
         npm publish --provenance --tag $TAG
       env:
-        NODE_AUTH_TOKEN: ${{ inputs.npm-token }}
         VERSION: ${{ inputs.version }}

--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -14,8 +14,6 @@ inputs:
     type: string
   github-token:
     required: true
-  npm-token:
-    required: true
 
 outputs:
   version:
@@ -62,7 +60,6 @@ runs:
         node-version: ${{ inputs.node-version }}
         require-build: ${{ inputs.require-build }}
         version: ${{ steps.get_version.outputs.version }}
-        npm-token: ${{ inputs.npm-token }}
         release-directory: ${{ inputs.release-directory }}
 
     # Create a release for the tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,4 +31,3 @@ jobs:
           require-build: true
           release-directory: ./
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          npm-token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### Description

Drop relying on an NPM Token, but use OIDC instead for publishing SDKs by configuring trusted publishers.

### References
https://docs.npmjs.com/trusted-publishers

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
