### PR TITLE
chore: bump npm to latest for trusted publisher

### DIFF
--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -26,6 +26,9 @@ runs:
         cache: 'npm'
         registry-url: 'https://registry.npmjs.org'
 
+    - name: Update npm
+      run: npm install -g npm@latest
+
     - name: Install dependencies
       shell: bash
       run: npm ci --include=dev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,9 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: "npm"
 
+      - name: Update npm
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: npm install
 
@@ -63,6 +66,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
+
+      - name: Update npm
+        run: npm install -g npm@latest
     
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
### Description

We need to install the latest version of npm to ensure we can rely on trusting the github action for publishing to npm.

### References

https://docs.npmjs.com/trusted-publishers

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
