### PR TITLE
chore: drop npmrc files

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-registry=https://registry.npmjs.org

--- a/examples/example-fastify-api/.npmrc
+++ b/examples/example-fastify-api/.npmrc
@@ -1,1 +1,0 @@
-registry=https://registry.npmjs.org

--- a/examples/example-fastify-web/.npmrc
+++ b/examples/example-fastify-web/.npmrc
@@ -1,1 +1,0 @@
-registry=https://registry.npmjs.org


### PR DESCRIPTION
### Description

To allow for private registries to be used, we are removing the npmrc file.

### References

N/A

### Testing

N/A

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
