### PR TITLE
fix(pipeline) missing shell in npm publish action

### DIFF
--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -26,6 +26,7 @@ runs:
         package-manager-cache: false
 
     - name: Update npm
+      shell: bash
       run: npm install -g npm@latest
 
     - name: Install dependencies


### PR DESCRIPTION
Fix the release pipeline failure by adding the missing shell: bash property to the Update `npm` step in `.github/actions/npm-publish/action.yml.` 

GitHub composite actions require shell on run steps, and the missing field caused the action manifest to fail validation before publish started.
