### PR TITLE
feat(auth0-fastify-api): add on-behalf-of-token-exchange support on  auth0-fastify-api

### DIFF
--- a/packages/auth0-fastify-api/EXAMPLES.md
+++ b/packages/auth0-fastify-api/EXAMPLES.md
@@ -230,7 +230,7 @@ The flow has three steps:
 2. **Exchange** the verified token for a new access token scoped to the downstream API.
 3. **Call** the downstream API using the exchanged token.
 
-`getTokenOnBehalfOf()` requires a confidential client. The plugin must be registered with `clientId` and at least one of `clientSecret`, a private key, or mTLS credentials. Calling it without client credentials throws `MissingClientAuthError`.
+`getTokenOnBehalfOf()` requires a confidential client. The plugin must be registered with `clientId` and at least one of `clientSecret` or `clientAssertionSigningKey`. Calling it without client credentials throws `MissingClientAuthError`.
 
 ### Plugin Registration
 
@@ -245,7 +245,7 @@ fastify.register(fastifyAuth0Api, {
   domain: '<AUTH0_DOMAIN>',          // your MCP server's Auth0 tenant domain
   audience: '<AUTH0_AUDIENCE>',      // your MCP server's API audience
   clientId: '<AUTH0_CLIENT_ID>',     // required for OBO
-  clientSecret: '<AUTH0_CLIENT_SECRET>', // required for OBO (or use privateKey / mTLS)
+  clientSecret: '<AUTH0_CLIENT_SECRET>', // required for OBO (or use clientAssertionSigningKey)
 });
 ```
 
@@ -321,7 +321,7 @@ On success, the method returns an `OnBehalfOfTokenResult` object containing:
 
 Two error types cover the failure scenarios you will encounter:
 
-- `MissingClientAuthError`: Thrown when `clientId` or client credentials (`clientSecret`, private key, or mTLS) are not configured on the plugin. This is a configuration error and will not be resolved at request time.
+- `MissingClientAuthError`: Thrown when `clientId` or client credentials (`clientSecret` or `clientAssertionSigningKey`) are not configured on the plugin. This is a configuration error and will not be resolved at request time.
 - `TokenExchangeError`: Thrown when Auth0 rejects the exchange. The error preserves the OAuth error code and description from Auth0 (for example, `invalid_target` when the client is not authorized to access the downstream API).
 
 Both are exported from `@auth0/auth0-fastify-api`:

--- a/packages/auth0-fastify-api/EXAMPLES.md
+++ b/packages/auth0-fastify-api/EXAMPLES.md
@@ -6,6 +6,7 @@
 - [Multiple Custom Domains (MCD)](#multiple-custom-domains-mcd)
 - [Discovery Cache Configuration](#discovery-cache-configuration)
 - [The `ApiClient` Instance](#the-apiclient-instance)
+- [On-Behalf-Of Token Exchange](#on-behalf-of-token-exchange)
 - [Protecting API Routes](#protecting-api-routes)
 
 ## Configuration
@@ -218,6 +219,192 @@ fastify.register(fastifyAuth0, {
 Once the plugin is registered, an instance of the Auth0 `ApiClient` is available via `fastify.auth0Client`. This instance can be used to call any of the methods available on the `ApiClient`, such as `verifyAccessToken()` and `getAccessTokenForConnection()`.
 
 For the complete list of available methods, please refer to the [@auth0/auth0-api-js SDK documentation](https://github.com/auth0/auth0-auth-js/blob/main/packages/auth0-api-js/README.md).
+
+## On-Behalf-Of Token Exchange
+
+Use `fastify.auth0Client.getTokenOnBehalfOf()` when your Fastify API receives an Auth0 access token for itself and needs to exchange it for another Auth0 access token targeting a downstream API, while preserving the same user identity. This is especially useful for MCP servers and other intermediary APIs that need to call downstream APIs on behalf of the user.
+
+The flow has three steps:
+
+1. **Verify** the incoming access token so your API rejects invalid or mis-targeted tokens before exchanging.
+2. **Exchange** the verified token for a new access token scoped to the downstream API.
+3. **Call** the downstream API using the exchanged token.
+
+`getTokenOnBehalfOf()` requires a confidential client. The plugin must be registered with `clientId` and at least one of `clientSecret`, a private key, or mTLS credentials. Calling it without client credentials throws `MissingClientAuthError`.
+
+### Plugin Registration
+
+When using OBO, configure the plugin with credentials in addition to `domain` and `audience`:
+
+```ts
+import fastifyAuth0Api from '@auth0/auth0-fastify-api';
+
+const fastify = Fastify({ logger: true });
+
+fastify.register(fastifyAuth0Api, {
+  domain: '<AUTH0_DOMAIN>',          // your MCP server's Auth0 tenant domain
+  audience: '<AUTH0_AUDIENCE>',      // your MCP server's API audience
+  clientId: '<AUTH0_CLIENT_ID>',     // required for OBO
+  clientSecret: '<AUTH0_CLIENT_SECRET>', // required for OBO (or use privateKey / mTLS)
+});
+```
+
+### Performing the Exchange
+
+Inside a route handler, verify the incoming token first, then exchange it for a downstream audience:
+
+```ts
+import type { FastifyRequest, FastifyReply } from 'fastify';
+import { getCurrentActor, getDelegationChain } from '@auth0/auth0-fastify-api';
+
+fastify.register(() => {
+  fastify.post(
+    '/schedule-meeting',
+    {
+      preHandler: fastify.requireAuth(),
+    },
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      // request.user is already verified by requireAuth()
+      const incomingAccessToken = request.getToken()!;
+
+      // Exchange the verified token for a token scoped to the downstream Calendar API.
+      // Pass the raw token — do not include the `Bearer ` prefix.
+      const obo = await fastify.auth0Client!.getTokenOnBehalfOf(incomingAccessToken, {
+        audience: 'https://calendar-api.example.com',
+        scope: 'calendar:read calendar:write',
+      });
+
+      // Call the downstream API with the exchanged token.
+      const response = await fetch('https://calendar-api.example.com/meetings', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${obo.accessToken}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify(request.body),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Calendar API request failed with ${response.status}`);
+      }
+
+      return { user: request.user.sub, meeting: await response.json() };
+    }
+  );
+});
+```
+
+> [!TIP]
+> **Production notes:**
+> - `requireAuth()` in the `preHandler` verifies the incoming token before your handler runs. Always protect routes with `requireAuth()` before calling `getTokenOnBehalfOf()`.
+> - `request.getToken()` returns the raw JWT from the `Authorization` header, without the `Bearer ` prefix. Pass this directly to `getTokenOnBehalfOf()`.
+> - The downstream `audience` must match an API identifier configured in your Auth0 tenant, and your client must be authorized to access it.
+> - `getTokenOnBehalfOf()` only returns access-token-oriented fields. It does not expose `idToken` or `refreshToken`.
+> - OBO requires a **confidential client**. Calling it without client credentials throws `MissingClientAuthError`.
+
+> [!NOTE]
+> **DPoP:** `getTokenOnBehalfOf()` forwards the incoming access token as the
+> [RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693#section-2.1) `subject_token`
+> and relies on Auth0 to handle any DPoP-specific behavior for that token.
+
+### `getTokenOnBehalfOf()` Return Value
+
+On success, the method returns an `OnBehalfOfTokenResult` object containing:
+
+- `accessToken`: The exchanged access token issued for the downstream API.
+- `expiresAt`: The access token expiration time, represented in seconds since the Unix epoch.
+- `scope`: The scope granted for the exchanged token, if returned.
+- `tokenType`: The returned token type, if returned.
+- `issuedTokenType`: The returned RFC 8693 issued token type, if returned.
+
+### Error Handling
+
+Two error types cover the failure scenarios you will encounter:
+
+- `MissingClientAuthError`: Thrown when `clientId` or client credentials (`clientSecret`, private key, or mTLS) are not configured on the plugin. This is a configuration error and will not be resolved at request time.
+- `TokenExchangeError`: Thrown when Auth0 rejects the exchange. The error preserves the OAuth error code and description from Auth0 (for example, `invalid_target` when the client is not authorized to access the downstream API).
+
+Both are exported from `@auth0/auth0-fastify-api`:
+
+```ts
+import fastifyAuth0Api, { MissingClientAuthError, TokenExchangeError } from '@auth0/auth0-fastify-api';
+
+try {
+  const obo = await fastify.auth0Client!.getTokenOnBehalfOf(incomingAccessToken, {
+    audience: 'https://calendar-api.example.com',
+  });
+} catch (err) {
+  if (err instanceof MissingClientAuthError) {
+    // Plugin is not configured with client credentials — fix the registration options.
+    throw err;
+  }
+  if (err instanceof TokenExchangeError) {
+    // Auth0 rejected the exchange. err.message contains the error_description from Auth0.
+    reply.code(502).send({ error: 'upstream_exchange_failed', detail: err.message });
+    return;
+  }
+  throw err;
+}
+```
+
+### Verifying an Exchanged Token on the Downstream API
+
+When the downstream API (for example, the Calendar API in the examples above) receives the exchanged token, it should verify the token, confirm that the current actor is an expected caller, and optionally record the delegation chain for audit logging.
+
+The exchanged token contains an `act` claim that identifies the actor that performed the exchange:
+
+```json
+{
+  "sub": "auth0|user123",
+  "aud": "https://calendar-api.example.com",
+  "azp": "<AUTH0_CLIENT_ID>",
+  "act": {
+    "sub": "<AUTH0_CLIENT_ID>"
+  }
+}
+```
+
+On the Calendar API (also a Fastify app using this plugin):
+
+```ts
+import fastifyAuth0Api, { getCurrentActor, getDelegationChain } from '@auth0/auth0-fastify-api';
+
+const calendarApi = Fastify({ logger: true });
+
+calendarApi.register(fastifyAuth0Api, {
+  domain: '<AUTH0_DOMAIN>',
+  audience: 'https://calendar-api.example.com',
+});
+
+const ALLOWED_ACTORS = ['<MCP_SERVER_CLIENT_ID>'];
+
+calendarApi.register(() => {
+  calendarApi.get(
+    '/meetings',
+    {
+      preHandler: calendarApi.requireAuth(),
+    },
+    async (request: FastifyRequest) => {
+      // Use only the top-level act.sub for authorization decisions (RFC 8693 §4.1).
+      const currentActor = getCurrentActor(request.user);
+      if (!currentActor || !ALLOWED_ACTORS.includes(currentActor)) {
+        throw { statusCode: 403, message: 'Actor not authorized' };
+      }
+
+      // Use the full delegation chain for logging or audit only — never for authorization.
+      const delegationChain = getDelegationChain(request.user);
+      request.log.info({ user: request.user.sub, currentActor, delegationChain }, 'delegated_request');
+
+      return { meetings: [] };
+    }
+  );
+});
+```
+
+> [!IMPORTANT]
+> Only the outermost `act.sub`, returned by `getCurrentActor()`, should be used for authorization
+> decisions. Nested `act` values represent prior actors in the delegation chain and are informational
+> only, per [RFC 8693 §4.1](https://datatracker.ietf.org/doc/html/rfc8693#section-4.1).
 
 ## Protecting API Routes
 

--- a/packages/auth0-fastify-api/README.md
+++ b/packages/auth0-fastify-api/README.md
@@ -95,7 +95,7 @@ fastify.register(() => {
 
 Use `fastify.auth0Client.getTokenOnBehalfOf()` when your Fastify API needs to call a downstream API on behalf of the same user, such as in an MCP server. The method exchanges the incoming access token for a new one scoped to the downstream API while preserving the user's identity.
 
-`getTokenOnBehalfOf()` requires a confidential client. Register the plugin with `clientId` and `clientSecret` (or a private key / mTLS credentials).
+`getTokenOnBehalfOf()` requires a confidential client. Register the plugin with `clientId` and `clientSecret` (or `clientAssertionSigningKey` for client assertion authentication).
 
 ```ts
 import fastifyAuth0Api from '@auth0/auth0-fastify-api';

--- a/packages/auth0-fastify-api/README.md
+++ b/packages/auth0-fastify-api/README.md
@@ -91,6 +91,52 @@ fastify.register(() => {
 > The above is to protect API routes by the means of a bearer token, and not server-side rendering routes using a session. 
 
 
+### On-Behalf-Of Token Exchange
+
+Use `fastify.auth0Client.getTokenOnBehalfOf()` when your Fastify API needs to call a downstream API on behalf of the same user, such as in an MCP server. The method exchanges the incoming access token for a new one scoped to the downstream API while preserving the user's identity.
+
+`getTokenOnBehalfOf()` requires a confidential client. Register the plugin with `clientId` and `clientSecret` (or a private key / mTLS credentials).
+
+```ts
+import fastifyAuth0Api from '@auth0/auth0-fastify-api';
+
+const fastify = Fastify({ logger: true });
+
+fastify.register(fastifyAuth0Api, {
+  domain: '<AUTH0_DOMAIN>',
+  audience: '<AUTH0_AUDIENCE>',
+  clientId: '<AUTH0_CLIENT_ID>',
+  clientSecret: '<AUTH0_CLIENT_SECRET>',
+});
+
+fastify.register(() => {
+  fastify.post(
+    '/schedule-meeting',
+    {
+      preHandler: fastify.requireAuth(),
+    },
+    async (request: FastifyRequest) => {
+      // request.getToken() returns the raw JWT without the `Bearer ` prefix.
+      const obo = await fastify.auth0Client!.getTokenOnBehalfOf(request.getToken()!, {
+        audience: 'https://calendar-api.example.com',
+        scope: 'calendar:read calendar:write',
+      });
+
+      const response = await fetch('https://calendar-api.example.com/meetings', {
+        method: 'POST',
+        headers: { authorization: `Bearer ${obo.accessToken}` },
+        body: JSON.stringify(request.body),
+      });
+
+      return response.json();
+    }
+  );
+});
+```
+
+For a full walkthrough including error handling, act claim inspection, and the downstream verifier pattern, see the [On-Behalf-Of Token Exchange](https://github.com/auth0/auth0-fastify/blob/main/packages/auth0-fastify-api/EXAMPLES.md#on-behalf-of-token-exchange) section in [EXAMPLES.md](https://github.com/auth0/auth0-fastify/blob/main/packages/auth0-fastify-api/EXAMPLES.md).
+
+
 ## Feedback
 
 ### Contributing

--- a/packages/auth0-fastify-api/package.json
+++ b/packages/auth0-fastify-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth0/auth0-fastify-api",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Auth0 SDK for Fastify API's on JavaScript runtimes",
   "author": "Auth0",
   "license": "MIT",
@@ -33,7 +33,7 @@
     "vitest": "^3.0.5"
   },
   "dependencies": {
-    "@auth0/auth0-api-js": "^1.5.0",
+    "@auth0/auth0-api-js": "^1.6.0",
     "fastify": "^5.3.2",
     "fastify-plugin": "^5.0.1"
   },

--- a/packages/auth0-fastify-api/src/index.spec.ts
+++ b/packages/auth0-fastify-api/src/index.spec.ts
@@ -507,11 +507,13 @@ test('should verify token with domains allowlist (no domain)', async () => {
 test('should pass request url and headers to domains resolver', async () => {
   addHandlersForDomain(secondaryDomain);
 
-  let resolvedContext: {
-    url?: string;
-    headers?: Record<string, string | string[] | undefined>;
-    unverifiedIss?: string;
-  } | undefined;
+  let resolvedContext:
+    | {
+        url?: string;
+        headers?: Record<string, string | string[] | undefined>;
+        unverifiedIss?: string;
+      }
+    | undefined;
 
   const fastify = Fastify({ trustProxy: true });
   fastify.register(fastifyAuth0Api, {
@@ -810,9 +812,11 @@ test('should return 401 when issuer not in resolved domains list', async () => {
 test('should ignore x-forwarded-host and x-forwarded-proto when trustProxy is disabled', async () => {
   addHandlersForDomain(secondaryDomain);
 
-  let resolvedContext: {
-    url?: string;
-  } | undefined;
+  let resolvedContext:
+    | {
+        url?: string;
+      }
+    | undefined;
 
   const fastify = Fastify();
   fastify.register(fastifyAuth0Api, {
@@ -855,9 +859,11 @@ test('should ignore x-forwarded-host and x-forwarded-proto when trustProxy is di
 test('should use x-forwarded-host and x-forwarded-proto when trustProxy is enabled', async () => {
   addHandlersForDomain(secondaryDomain);
 
-  let resolvedContext: {
-    url?: string;
-  } | undefined;
+  let resolvedContext:
+    | {
+        url?: string;
+      }
+    | undefined;
 
   const fastify = Fastify({ trustProxy: true });
   fastify.register(fastifyAuth0Api, {
@@ -994,6 +1000,73 @@ test('getTokenOnBehalfOf - should exchange an access token using fixed OBO token
     issuedTokenType: 'urn:ietf:params:oauth:token-type:access_token',
   });
   expect(result.tokenType?.toLowerCase()).toBe('bearer');
+});
+
+test('getTokenOnBehalfOf - should exchange an access token using client assertion authentication', async () => {
+  const capturedBody: { current?: URLSearchParams } = {};
+  const keyPair = (await crypto.subtle.generateKey(
+    {
+      name: 'RSASSA-PKCS1-v1_5',
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: 'SHA-256',
+    },
+    true,
+    ['sign', 'verify']
+  )) as CryptoKeyPair;
+
+  server.use(
+    http.post(`https://${domain}/custom/token`, async ({ request }) => {
+      capturedBody.current = new URLSearchParams(await request.text());
+
+      if (
+        capturedBody.current.get('grant_type') === 'urn:ietf:params:oauth:grant-type:token-exchange' &&
+        capturedBody.current.get('client_id') === 'my-client-id' &&
+        capturedBody.current.get('client_secret') === null &&
+        capturedBody.current.get('client_assertion') &&
+        capturedBody.current.get('client_assertion_type') ===
+          'urn:ietf:params:oauth:client-assertion-type:jwt-bearer' &&
+        capturedBody.current.get('subject_token') === 'incoming-access-token' &&
+        capturedBody.current.get('subject_token_type') === 'urn:ietf:params:oauth:token-type:access_token' &&
+        capturedBody.current.get('requested_token_type') === 'urn:ietf:params:oauth:token-type:access_token' &&
+        capturedBody.current.get('audience') === 'https://calendar-api.example.com'
+      ) {
+        return HttpResponse.json(
+          {
+            access_token: 'obo-access-token',
+            expires_in: 3600,
+            token_type: 'Bearer',
+            issued_token_type: 'urn:ietf:params:oauth:token-type:access_token',
+          },
+          { status: 200 }
+        );
+      }
+
+      return HttpResponse.json(
+        { error: 'invalid_request', error_description: 'Unexpected request parameters.' },
+        { status: 400 }
+      );
+    })
+  );
+
+  const fastify = Fastify();
+  fastify.register(fastifyAuth0Api, {
+    domain,
+    audience: '<audience>',
+    clientId: 'my-client-id',
+    clientAssertionSigningKey: keyPair.privateKey,
+  });
+
+  await fastify.ready();
+
+  const result = await fastify.auth0Client!.getTokenOnBehalfOf('incoming-access-token', {
+    audience: 'https://calendar-api.example.com',
+  });
+
+  expect(capturedBody.current).toBeDefined();
+  expect(capturedBody.current?.get('client_assertion')).toBeTruthy();
+  expect(capturedBody.current?.get('client_secret')).toBeNull();
+  expect(result.accessToken).toBe('obo-access-token');
 });
 
 test('getTokenOnBehalfOf - should not expose idToken or refreshToken', async () => {

--- a/packages/auth0-fastify-api/src/index.spec.ts
+++ b/packages/auth0-fastify-api/src/index.spec.ts
@@ -3,7 +3,7 @@ import { setupServer } from 'msw/node';
 import { http, HttpResponse } from 'msw';
 import { generateToken, jwks } from './test-utils/tokens.js';
 import Fastify from 'fastify';
-import fastifyAuth0Api from './index.js';
+import fastifyAuth0Api, { MissingClientAuthError, TokenExchangeError } from './index.js';
 
 const createOpenIdConfiguration = (domain: string) => ({
   issuer: `https://${domain}/`,
@@ -895,4 +895,212 @@ test('should use x-forwarded-host and x-forwarded-proto when trustProxy is enabl
 
   expect(res.statusCode).toBe(200);
   expect(resolvedContext?.url).toBe('https://api.forwarded.example.com/test?x=1');
+});
+
+// ---------------------------------------------------------------------------
+// getTokenOnBehalfOf tests
+// ---------------------------------------------------------------------------
+
+test('getTokenOnBehalfOf - should throw MissingClientAuthError when no clientId configured', async () => {
+  const fastify = Fastify();
+  fastify.register(fastifyAuth0Api, {
+    domain,
+    audience: '<audience>',
+  });
+
+  await fastify.ready();
+
+  await expect(
+    fastify.auth0Client!.getTokenOnBehalfOf('incoming-access-token', {
+      audience: 'https://calendar-api.example.com',
+    })
+  ).rejects.toThrow(MissingClientAuthError);
+});
+
+test('getTokenOnBehalfOf - should throw MissingClientAuthError when clientSecret is not configured', async () => {
+  const fastify = Fastify();
+  fastify.register(fastifyAuth0Api, {
+    domain,
+    audience: '<audience>',
+    clientId: 'my-client-id',
+    // no clientSecret — should throw
+  });
+
+  await fastify.ready();
+
+  await expect(
+    fastify.auth0Client!.getTokenOnBehalfOf('incoming-access-token', {
+      audience: 'https://calendar-api.example.com',
+    })
+  ).rejects.toThrow(MissingClientAuthError);
+});
+
+test('getTokenOnBehalfOf - should exchange an access token using fixed OBO token types', async () => {
+  let capturedBody: URLSearchParams | null = null;
+
+  server.use(
+    http.post(`https://${domain}/custom/token`, async ({ request }) => {
+      capturedBody = new URLSearchParams(await request.text());
+
+      if (
+        capturedBody.get('grant_type') === 'urn:ietf:params:oauth:grant-type:token-exchange' &&
+        capturedBody.get('client_id') === 'my-client-id' &&
+        capturedBody.get('client_secret') === 'my-client-secret' &&
+        capturedBody.get('subject_token') === 'incoming-access-token' &&
+        capturedBody.get('subject_token_type') === 'urn:ietf:params:oauth:token-type:access_token' &&
+        capturedBody.get('requested_token_type') === 'urn:ietf:params:oauth:token-type:access_token' &&
+        capturedBody.get('audience') === 'https://calendar-api.example.com' &&
+        capturedBody.get('scope') === 'calendar:read calendar:write'
+      ) {
+        return HttpResponse.json(
+          {
+            access_token: 'obo-access-token',
+            expires_in: 3600,
+            scope: 'calendar:read calendar:write',
+            token_type: 'Bearer',
+            issued_token_type: 'urn:ietf:params:oauth:token-type:access_token',
+          },
+          { status: 200 }
+        );
+      }
+
+      return HttpResponse.json(
+        { error: 'invalid_request', error_description: 'Unexpected request parameters.' },
+        { status: 400 }
+      );
+    })
+  );
+
+  const fastify = Fastify();
+  fastify.register(fastifyAuth0Api, {
+    domain,
+    audience: '<audience>',
+    clientId: 'my-client-id',
+    clientSecret: 'my-client-secret',
+  });
+
+  await fastify.ready();
+
+  const result = await fastify.auth0Client!.getTokenOnBehalfOf('incoming-access-token', {
+    audience: 'https://calendar-api.example.com',
+    scope: 'calendar:read calendar:write',
+  });
+
+  expect(capturedBody).not.toBeNull();
+  expect(result).toMatchObject({
+    accessToken: 'obo-access-token',
+    expiresAt: expect.any(Number),
+    scope: 'calendar:read calendar:write',
+    issuedTokenType: 'urn:ietf:params:oauth:token-type:access_token',
+  });
+  expect(result.tokenType?.toLowerCase()).toBe('bearer');
+});
+
+test('getTokenOnBehalfOf - should not expose idToken or refreshToken', async () => {
+  // Auth0 does not return id_token or refresh_token as part of the OBO contract,
+  // but if they are present in the response the SDK must strip them from the result.
+  // Including id_token in the mock causes openid-client to attempt OIDC validation
+  // (nonce, azp, etc.) which always fails in a token exchange context, so only
+  // refresh_token is included here to cover the stripping assertion.
+  server.use(
+    http.post(`https://${domain}/custom/token`, async () => {
+      return HttpResponse.json(
+        {
+          access_token: 'obo-access-token',
+          expires_in: 3600,
+          token_type: 'Bearer',
+          issued_token_type: 'urn:ietf:params:oauth:token-type:access_token',
+          refresh_token: 'some-refresh-token',
+        },
+        { status: 200 }
+      );
+    })
+  );
+
+  const fastify = Fastify();
+  fastify.register(fastifyAuth0Api, {
+    domain,
+    audience: '<audience>',
+    clientId: 'my-client-id',
+    clientSecret: 'my-client-secret',
+  });
+
+  await fastify.ready();
+
+  const result = await fastify.auth0Client!.getTokenOnBehalfOf('incoming-access-token', {
+    audience: 'https://calendar-api.example.com',
+  });
+
+  expect(result).not.toHaveProperty('idToken');
+  expect(result).not.toHaveProperty('refreshToken');
+  expect(result.accessToken).toBe('obo-access-token');
+});
+
+test('getTokenOnBehalfOf - should throw TokenExchangeError when Auth0 rejects the exchange', async () => {
+  server.use(
+    http.post(`https://${domain}/custom/token`, () => {
+      return HttpResponse.json(
+        {
+          error: 'invalid_target',
+          error_description:
+            "The MCP server 'my-client-id' is not authorized to access the API 'https://calendar-api.example.com'.",
+        },
+        { status: 400 }
+      );
+    })
+  );
+
+  const fastify = Fastify();
+  fastify.register(fastifyAuth0Api, {
+    domain,
+    audience: '<audience>',
+    clientId: 'my-client-id',
+    clientSecret: 'my-client-secret',
+  });
+
+  await fastify.ready();
+
+  await expect(
+    fastify.auth0Client!.getTokenOnBehalfOf('incoming-access-token', {
+      audience: 'https://calendar-api.example.com',
+    })
+  ).rejects.toThrow(TokenExchangeError);
+});
+
+test('getTokenOnBehalfOf - should work with scope omitted (no scope in request)', async () => {
+  let capturedScope: string | null = 'not-set';
+
+  server.use(
+    http.post(`https://${domain}/custom/token`, async ({ request }) => {
+      const body = new URLSearchParams(await request.text());
+      capturedScope = body.get('scope');
+      return HttpResponse.json(
+        {
+          access_token: 'obo-access-token',
+          expires_in: 3600,
+          token_type: 'Bearer',
+          issued_token_type: 'urn:ietf:params:oauth:token-type:access_token',
+        },
+        { status: 200 }
+      );
+    })
+  );
+
+  const fastify = Fastify();
+  fastify.register(fastifyAuth0Api, {
+    domain,
+    audience: '<audience>',
+    clientId: 'my-client-id',
+    clientSecret: 'my-client-secret',
+  });
+
+  await fastify.ready();
+
+  const result = await fastify.auth0Client!.getTokenOnBehalfOf('incoming-access-token', {
+    audience: 'https://calendar-api.example.com',
+    // scope intentionally omitted
+  });
+
+  expect(capturedScope).toBeNull();
+  expect(result.accessToken).toBe('obo-access-token');
 });

--- a/packages/auth0-fastify-api/src/index.ts
+++ b/packages/auth0-fastify-api/src/index.ts
@@ -38,20 +38,20 @@ type Auth0FastifyApiCommonOptions = {
   algorithms?: string[];
   /**
    * The optional client ID of the application.
-    * Required when using the `getAccessTokenForConnection`, `getTokenByExchangeProfile`,
-    * or `getTokenOnBehalfOf` methods.
+   * Required when using the `getAccessTokenForConnection`, `getTokenByExchangeProfile`,
+   * or `getTokenOnBehalfOf` methods.
    */
   clientId?: string;
   /**
    * The optional client secret of the application.
    * At least one of `clientSecret` or `clientAssertionSigningKey` is required when using the
-    * `getAccessTokenForConnection`, `getTokenByExchangeProfile`, or `getTokenOnBehalfOf` methods.
+   * `getAccessTokenForConnection`, `getTokenByExchangeProfile`, or `getTokenOnBehalfOf` methods.
    */
   clientSecret?: string;
   /**
    * The optional client assertion signing key to use.
    * At least one of `clientSecret` or `clientAssertionSigningKey` is required when using the
-    * `getAccessTokenForConnection`, `getTokenByExchangeProfile`, or `getTokenOnBehalfOf` methods.
+   * `getAccessTokenForConnection`, `getTokenByExchangeProfile`, or `getTokenOnBehalfOf` methods.
    */
   clientAssertionSigningKey?: string | CryptoKey;
   /**
@@ -233,5 +233,10 @@ function buildRequestUrl(request: FastifyRequest): string | undefined {
   return `${request.protocol}://${request.host}${request.url}`;
 }
 
-export type { DomainsResolver, DomainsResolverContext, OnBehalfOfTokenOptions, OnBehalfOfTokenResult } from '@auth0/auth0-api-js';
+export type {
+  DomainsResolver,
+  DomainsResolverContext,
+  OnBehalfOfTokenOptions,
+  OnBehalfOfTokenResult,
+} from '@auth0/auth0-api-js';
 export { getCurrentActor, getDelegationChain, MissingClientAuthError, TokenExchangeError } from '@auth0/auth0-api-js';

--- a/packages/auth0-fastify-api/src/index.ts
+++ b/packages/auth0-fastify-api/src/index.ts
@@ -38,19 +38,20 @@ type Auth0FastifyApiCommonOptions = {
   algorithms?: string[];
   /**
    * The optional client ID of the application.
-   * Required when using the `getAccessTokenForConnection` method.
+    * Required when using the `getAccessTokenForConnection`, `getTokenByExchangeProfile`,
+    * or `getTokenOnBehalfOf` methods.
    */
   clientId?: string;
   /**
    * The optional client secret of the application.
    * At least one of `clientSecret` or `clientAssertionSigningKey` is required when using the
-   * `getAccessTokenForConnection` method.
+    * `getAccessTokenForConnection`, `getTokenByExchangeProfile`, or `getTokenOnBehalfOf` methods.
    */
   clientSecret?: string;
   /**
    * The optional client assertion signing key to use.
    * At least one of `clientSecret` or `clientAssertionSigningKey` is required when using the
-   * `getAccessTokenForConnection` method.
+    * `getAccessTokenForConnection`, `getTokenByExchangeProfile`, or `getTokenOnBehalfOf` methods.
    */
   clientAssertionSigningKey?: string | CryptoKey;
   /**

--- a/packages/auth0-fastify-api/src/index.ts
+++ b/packages/auth0-fastify-api/src/index.ts
@@ -232,4 +232,5 @@ function buildRequestUrl(request: FastifyRequest): string | undefined {
   return `${request.protocol}://${request.host}${request.url}`;
 }
 
-export type { DomainsResolver, DomainsResolverContext } from '@auth0/auth0-api-js';
+export type { DomainsResolver, DomainsResolverContext, OnBehalfOfTokenOptions, OnBehalfOfTokenResult } from '@auth0/auth0-api-js';
+export { getCurrentActor, getDelegationChain, MissingClientAuthError, TokenExchangeError } from '@auth0/auth0-api-js';


### PR DESCRIPTION
Exposes `getTokenOnBehalfOf()` on `fastify.auth0Client` by bumping the `@auth0/auth0-api-js` dependency to `^1.6.0`, which ships the `OBO-TE (On Behalf Of Token Exchange)` feature.

### Changes
`fastify.auth0Client.getTokenOnBehalfOf(incomingToken, { audience, scope? })`: exchanges an incoming `Auth0` access token for one scoped to a downstream API, preserving the user's identity (sub) and stamping the actor (act claim)
Re-exports `OnBehalfOfTokenOptions`, `OnBehalfOfTokenResult`, `getCurrentActor`, `getDelegationChain`, `MissingClientAuthError`, and `TokenExchangeError` directly from `@auth0/auth0-fastify-api`