### PR TITLE
feat(auth0-fastify-api): Add DPoP support on auth0-fastify-api

### DIFF
--- a/packages/auth0-fastify-api/EXAMPLES.md
+++ b/packages/auth0-fastify-api/EXAMPLES.md
@@ -335,6 +335,14 @@ fastify.register(fastifyAuth0Api, {
 });
 ```
 
+### Hostname Resolution (`request.host` and `request.protocol`)
+
+This SDK uses `request.protocol` and `request.host` to construct the URL used for validating the DPoP proof's `htu` (HTTP URI) claim. If your application is behind a reverse proxy (e.g., Nginx, Cloudflare), you must enable proxy trust:
+
+```ts
+const fastify = Fastify({ trustProxy: true });
+```
+
 > [!IMPORTANT]
 > The only supported DPoP proof algorithm is **ES256**. The SDK rejects proofs signed with other algorithms.
 

--- a/packages/auth0-fastify-api/EXAMPLES.md
+++ b/packages/auth0-fastify-api/EXAMPLES.md
@@ -5,6 +5,7 @@
   - [Configuring a `customFetch` Implementation](#configuring-a-customfetch-implementation)
 - [Multiple Custom Domains (MCD)](#multiple-custom-domains-mcd)
 - [Discovery Cache Configuration](#discovery-cache-configuration)
+- [DPoP (Demonstration of Proof-of-Possession)](#dpop-demonstration-of-proof-of-possession)
 - [The `ApiClient` Instance](#the-apiclient-instance)
 - [On-Behalf-Of Token Exchange](#on-behalf-of-token-exchange)
 - [Protecting API Routes](#protecting-api-routes)
@@ -213,6 +214,132 @@ fastify.register(fastifyAuth0, {
   discoveryCache: { ttl: 600, maxEntries: 100 },
 });
 ```
+
+## DPoP (Demonstration of Proof-of-Possession)
+
+[DPoP (RFC 9449)](https://datatracker.ietf.org/doc/html/rfc9449) is a mechanism that binds access tokens to a specific client key pair. Even if a DPoP-bound token is stolen, it cannot be used without the corresponding private key, significantly reducing the impact of token theft.
+
+### How DPoP Works
+
+1. The client generates an asymmetric key pair (ES256).
+2. When requesting a token from Auth0, the client presents a DPoP proof JWT signed with its private key.
+3. Auth0 issues an access token bound to that key via the `cnf.jkt` (confirmation JSON Key Thumbprint) claim.
+4. When calling your API, the client sends:
+   - `Authorization: DPoP <access_token>` (not `Bearer`)
+   - `DPoP: <proof_jwt>` header containing a proof JWT tied to the HTTP method and URL
+
+The SDK automatically extracts the DPoP proof, validates the binding, and verifies the proof against the request.
+
+### Configuration
+
+Configure DPoP behavior using the `dpop` option:
+
+```ts
+import fastifyAuth0Api, { type DPoPOptions } from '@auth0/auth0-fastify-api';
+
+const fastify = Fastify({ logger: true });
+
+fastify.register(fastifyAuth0Api, {
+  domain: '<AUTH0_DOMAIN>',
+  audience: '<AUTH0_AUDIENCE>',
+  dpop: {
+    mode: 'required',    // 'allowed' | 'required' | 'disabled'
+    iatOffset: 300,      // max age of proof in seconds (default: 300)
+    iatLeeway: 30,       // future clock skew tolerance in seconds (default: 30)
+  },
+});
+```
+
+### DPoP Modes
+
+| Mode | Behavior |
+|------|----------|
+| `allowed` (default) | Accepts both Bearer tokens and DPoP-bound tokens. When a DPoP proof is present or the token contains a `cnf.jkt` claim, DPoP validation is performed. |
+| `required` | Only DPoP-bound tokens are accepted. Bearer tokens are rejected with a `DPoP` challenge in `WWW-Authenticate`. |
+| `disabled` | DPoP is completely ignored. Only Bearer tokens are accepted. |
+
+### Route Protection with DPoP
+
+No changes are needed in your route handlers. The `requireAuth()` preHandler automatically handles DPoP validation:
+
+```ts
+fastify.register(() => {
+  fastify.get(
+    '/protected-resource',
+    {
+      preHandler: fastify.requireAuth({ scopes: 'read:data' }),
+    },
+    async (request: FastifyRequest) => {
+      // request.user contains the verified token claims
+      // Works identically for both Bearer and DPoP-bound tokens
+      return { data: request.user.sub };
+    }
+  );
+});
+```
+
+### Error Handling
+
+DPoP introduces additional error types. All are exported from `@auth0/auth0-fastify-api`:
+
+```ts
+import fastifyAuth0Api, {
+  InvalidDpopProofError,
+  InvalidRequestError,
+  VerifyAccessTokenError,
+} from '@auth0/auth0-fastify-api';
+```
+
+| Error Class | HTTP Status | When |
+|-------------|-------------|------|
+| `InvalidDpopProofError` | 400 | The DPoP proof JWT fails validation (wrong method, URL, expired, bad signature, etc.) |
+| `InvalidRequestError` | 400 | Missing DPoP proof when required, invalid authentication scheme, or scheme mismatch |
+| `VerifyAccessTokenError` | 401 | Token verification fails (expired, bad signature, missing `cnf.jkt` for DPoP scheme, etc.) |
+
+The SDK returns RFC-compliant `WWW-Authenticate` response headers with appropriate challenges:
+
+- **Mode `allowed`**: `Bearer realm="api", ..., DPoP algs="ES256"`
+- **Mode `required`**: `DPoP algs="ES256", error="...", error_description="..."`
+- **Mode `disabled`**: `Bearer realm="api", error="...", error_description="..."`
+
+### DPoP with Multiple Custom Domains
+
+DPoP works seamlessly with the Multiple Custom Domains (MCD) feature. The `httpUrl` used for DPoP proof validation is derived from the same request URL used for domain resolution:
+
+```ts
+fastify.register(fastifyAuth0Api, {
+  audience: '<AUTH0_AUDIENCE>',
+  domains: ['brand1.auth.example.com', 'brand2.auth.example.com'],
+  dpop: { mode: 'required' },
+});
+```
+
+### Timing Configuration
+
+The `iatOffset` and `iatLeeway` options control how the SDK validates the DPoP proof's `iat` (issued-at) claim:
+
+- **`iatOffset`** (default: 300 seconds): Maximum age of a DPoP proof. A proof issued more than `iatOffset` seconds ago is rejected.
+- **`iatLeeway`** (default: 30 seconds): Allowed future clock skew. A proof with `iat` up to `iatLeeway` seconds in the future is accepted.
+
+The acceptable `iat` window is: `[now - iatOffset, now + iatLeeway]`.
+
+```ts
+fastify.register(fastifyAuth0Api, {
+  domain: '<AUTH0_DOMAIN>',
+  audience: '<AUTH0_AUDIENCE>',
+  dpop: {
+    mode: 'allowed',
+    iatOffset: 600,  // accept proofs up to 10 minutes old
+    iatLeeway: 60,   // allow up to 60 seconds of future clock skew
+  },
+});
+```
+
+> [!IMPORTANT]
+> The only supported DPoP proof algorithm is **ES256**. The SDK rejects proofs signed with other algorithms.
+
+> [!NOTE]
+> When `dpop.mode` is not set, it defaults to `'allowed'`, meaning your existing Bearer-token clients continue to work without any changes while DPoP-capable clients can opt in.
 
 ## The `ApiClient` Instance
 

--- a/packages/auth0-fastify-api/README.md
+++ b/packages/auth0-fastify-api/README.md
@@ -91,6 +91,34 @@ fastify.register(() => {
 > The above is to protect API routes by the means of a bearer token, and not server-side rendering routes using a session. 
 
 
+### DPoP (Demonstration of Proof-of-Possession)
+
+DPoP binds access tokens to a specific client's key pair, preventing stolen tokens from being replayed by attackers. The SDK supports DPoP with three modes:
+
+- **`allowed`** (default): accepts both Bearer and DPoP-bound tokens.
+- **`required`**: only DPoP-bound tokens are accepted; Bearer tokens are rejected.
+- **`disabled`**: DPoP is ignored; Bearer-only behavior.
+
+```ts
+import fastifyAuth0Api from '@auth0/auth0-fastify-api';
+
+const fastify = Fastify({ logger: true });
+
+fastify.register(fastifyAuth0Api, {
+  domain: '<AUTH0_DOMAIN>',
+  audience: '<AUTH0_AUDIENCE>',
+  dpop: { mode: 'required' },
+});
+```
+
+When DPoP is enabled, clients send:
+1. An `Authorization: DPoP <access_token>` header (instead of `Bearer`).
+2. A `DPoP` header containing a proof JWT tied to the request method and URL.
+
+The SDK automatically extracts the DPoP proof from the request, validates it against the access token's `cnf.jkt` claim, and verifies that the proof matches the current HTTP method and URL.
+
+For the full configuration reference and error handling details, see the [DPoP section in EXAMPLES.md](https://github.com/auth0/auth0-fastify/blob/main/packages/auth0-fastify-api/EXAMPLES.md#dpop-demonstration-of-proof-of-possession).
+
 ### On-Behalf-Of Token Exchange
 
 Use `fastify.auth0Client.getTokenOnBehalfOf()` when your Fastify API needs to call a downstream API on behalf of the same user, such as in an MCP server. The method exchanges the incoming access token for a new one scoped to the downstream API while preserving the user's identity.

--- a/packages/auth0-fastify-api/package.json
+++ b/packages/auth0-fastify-api/package.json
@@ -33,7 +33,7 @@
     "vitest": "^3.0.5"
   },
   "dependencies": {
-    "@auth0/auth0-api-js": "^1.6.0",
+    "@auth0/auth0-api-js": "^1.6.1",
     "fastify": "^5.3.2",
     "fastify-plugin": "^5.0.1"
   },

--- a/packages/auth0-fastify-api/src/dpop.spec.ts
+++ b/packages/auth0-fastify-api/src/dpop.spec.ts
@@ -193,6 +193,26 @@ describe('DPoP mode: allowed (default)', () => {
     expect(res.json().error).toBe('invalid_dpop_proof');
   });
 
+  test('should reject DPoP scheme without proof in allowed mode', async () => {
+    const fastify = Fastify();
+    fastify.register(fastifyAuth0Api, { domain, audience });
+
+    fastify.register(() => {
+      fastify.get('/test', { preHandler: fastify.requireAuth() }, async () => 'OK');
+    });
+
+    const accessToken = await signAccessToken({ cnfJkt: ecThumbprint });
+
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/test',
+      headers: { authorization: `DPoP ${accessToken}` },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe('invalid_request');
+  });
+
   test('should reject DPoP scheme when token has no cnf.jkt', async () => {
     const fastify = Fastify();
     fastify.register(fastifyAuth0Api, { domain, audience });

--- a/packages/auth0-fastify-api/src/dpop.spec.ts
+++ b/packages/auth0-fastify-api/src/dpop.spec.ts
@@ -459,6 +459,65 @@ describe('DPoP mode: disabled', () => {
 });
 
 // ---------------------------------------------------------------------------
+// DPoP URL construction (trustProxy behavior)
+// ---------------------------------------------------------------------------
+
+describe('DPoP URL construction', () => {
+  test('should reject DPoP proof when trustProxy is disabled and proof htu uses forwarded host', async () => {
+    const fastify = Fastify({ trustProxy: false });
+    fastify.register(fastifyAuth0Api, { domain, audience });
+
+    fastify.register(() => {
+      fastify.get('/test', { preHandler: fastify.requireAuth() }, async () => 'OK');
+    });
+
+    const accessToken = await signAccessToken({ cnfJkt: ecThumbprint });
+    // Proof was created for proxy host, but trustProxy is disabled so SDK sees localhost
+    const dpopProof = await createDpopProof(accessToken, 'GET', 'https://proxy.example.com/test');
+
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/test',
+      headers: {
+        authorization: `DPoP ${accessToken}`,
+        dpop: dpopProof,
+        'x-forwarded-host': 'proxy.example.com',
+        'x-forwarded-proto': 'https',
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe('invalid_dpop_proof');
+  });
+
+  test('should accept DPoP proof when trustProxy is enabled and proof htu uses forwarded host', async () => {
+    const fastify = Fastify({ trustProxy: true });
+    fastify.register(fastifyAuth0Api, { domain, audience });
+
+    fastify.register(() => {
+      fastify.get('/test', { preHandler: fastify.requireAuth() }, async () => 'OK');
+    });
+
+    const accessToken = await signAccessToken({ cnfJkt: ecThumbprint });
+    const dpopProof = await createDpopProof(accessToken, 'GET', 'https://proxy.example.com/test');
+
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/test',
+      headers: {
+        authorization: `DPoP ${accessToken}`,
+        dpop: dpopProof,
+        'x-forwarded-host': 'proxy.example.com',
+        'x-forwarded-proto': 'https',
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBe('OK');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // DPoP proof validation details
 // ---------------------------------------------------------------------------
 

--- a/packages/auth0-fastify-api/src/dpop.spec.ts
+++ b/packages/auth0-fastify-api/src/dpop.spec.ts
@@ -1,0 +1,687 @@
+import { expect, test, afterAll, afterEach, beforeAll, describe } from 'vitest';
+import { setupServer } from 'msw/node';
+import { http, HttpResponse } from 'msw';
+import { calculateJwkThumbprint, exportJWK, generateKeyPair, SignJWT } from 'jose';
+import type { JWK } from 'jose';
+import Fastify from 'fastify';
+import fastifyAuth0Api, { InvalidDpopProofError, InvalidRequestError, VerifyAccessTokenError } from './index.js';
+
+const issuer = 'https://dpop-test.auth0.local/';
+const audience = 'https://api.example.com';
+
+const discoveryUrl = `${issuer}.well-known/openid-configuration`;
+const jwksUrl = `${issuer}.well-known/jwks.json`;
+const domain = 'dpop-test.auth0.local';
+
+let rsaPrivateKey: CryptoKey;
+let rsaPublicJwk: JWK;
+let ecPrivateKey: CryptoKey;
+let ecPublicJwk: JWK;
+let ecThumbprint: string;
+
+const handlers = [
+  http.get(discoveryUrl, () =>
+    HttpResponse.json({
+      issuer,
+      jwks_uri: jwksUrl,
+      token_endpoint: `${issuer}oauth/token`,
+    })
+  ),
+  http.get(jwksUrl, () => HttpResponse.json({ keys: [rsaPublicJwk] })),
+];
+
+const server = setupServer(...handlers);
+
+beforeAll(async () => {
+  const rsa = await generateKeyPair('RS256');
+  rsaPrivateKey = rsa.privateKey;
+  rsaPublicJwk = await exportJWK(rsa.publicKey);
+  (rsaPublicJwk as Record<string, unknown>).alg = 'RS256';
+
+  const ec = await generateKeyPair('ES256');
+  ecPrivateKey = ec.privateKey;
+  ecPublicJwk = await exportJWK(ec.publicKey);
+  (ecPublicJwk as Record<string, unknown>).alg = 'ES256';
+  ecThumbprint = await calculateJwkThumbprint(ecPublicJwk);
+
+  server.listen({ onUnhandledRequest: 'error' });
+});
+
+afterAll(() => server.close());
+afterEach(() => server.resetHandlers());
+
+async function computeAth(token: string): Promise<string> {
+  const data = new TextEncoder().encode(token);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return btoa(String.fromCharCode(...hashArray))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+async function signAccessToken(opts?: { cnfJkt?: string; claims?: Record<string, unknown> }): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  const payload: Record<string, unknown> = {
+    ...(opts?.claims || {}),
+    ...(opts?.cnfJkt ? { cnf: { jkt: opts.cnfJkt } } : {}),
+  };
+
+  return new SignJWT(payload)
+    .setProtectedHeader({ alg: 'RS256' })
+    .setIssuer(issuer)
+    .setAudience(audience)
+    .setIssuedAt(now)
+    .setExpirationTime(now + 3600)
+    .setSubject('user_123')
+    .sign(rsaPrivateKey);
+}
+
+async function createDpopProof(
+  accessToken: string,
+  method: string,
+  url: string,
+  opts?: { invalidAth?: boolean; expiredIat?: boolean }
+): Promise<string> {
+  const ath = opts?.invalidAth ? 'bad-ath-value' : await computeAth(accessToken);
+  const iat = opts?.expiredIat ? Math.floor(Date.now() / 1000) - 600 : Math.floor(Date.now() / 1000);
+
+  return new SignJWT({
+    htm: method,
+    htu: url,
+    iat,
+    jti: crypto.randomUUID(),
+    ath,
+  })
+    .setProtectedHeader({ alg: 'ES256', typ: 'dpop+jwt', jwk: ecPublicJwk })
+    .sign(ecPrivateKey);
+}
+
+// ---------------------------------------------------------------------------
+// DPoP mode: 'allowed' (default)
+// ---------------------------------------------------------------------------
+
+describe('DPoP mode: allowed (default)', () => {
+  test('should accept a valid Bearer token without DPoP proof', async () => {
+    const fastify = Fastify();
+    fastify.register(fastifyAuth0Api, { domain, audience });
+
+    fastify.register(() => {
+      fastify.get('/test', { preHandler: fastify.requireAuth() }, async () => 'OK');
+    });
+
+    const accessToken = await signAccessToken();
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/test',
+      headers: { authorization: `Bearer ${accessToken}` },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBe('OK');
+  });
+
+  test('should accept a valid DPoP-bound token with valid proof', async () => {
+    const fastify = Fastify();
+    fastify.register(fastifyAuth0Api, { domain, audience });
+
+    fastify.register(() => {
+      fastify.get('/test', { preHandler: fastify.requireAuth() }, async () => 'OK');
+    });
+
+    const accessToken = await signAccessToken({ cnfJkt: ecThumbprint });
+    const dpopProof = await createDpopProof(accessToken, 'GET', 'http://localhost:80/test');
+
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/test',
+      headers: {
+        authorization: `DPoP ${accessToken}`,
+        dpop: dpopProof,
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBe('OK');
+  });
+
+  test('should reject DPoP-bound token presented with Bearer scheme', async () => {
+    const fastify = Fastify();
+    fastify.register(fastifyAuth0Api, { domain, audience });
+
+    fastify.register(() => {
+      fastify.get('/test', { preHandler: fastify.requireAuth() }, async () => 'OK');
+    });
+
+    const accessToken = await signAccessToken({ cnfJkt: ecThumbprint });
+    const dpopProof = await createDpopProof(accessToken, 'GET', 'http://localhost:80/test');
+
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/test',
+      headers: {
+        authorization: `Bearer ${accessToken}`,
+        dpop: dpopProof,
+      },
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.json().error).toBe('invalid_token');
+  });
+
+  test('should reject DPoP scheme with invalid proof (bad ath)', async () => {
+    const fastify = Fastify();
+    fastify.register(fastifyAuth0Api, { domain, audience });
+
+    fastify.register(() => {
+      fastify.get('/test', { preHandler: fastify.requireAuth() }, async () => 'OK');
+    });
+
+    const accessToken = await signAccessToken({ cnfJkt: ecThumbprint });
+    const dpopProof = await createDpopProof(accessToken, 'GET', 'http://localhost:80/test', { invalidAth: true });
+
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/test',
+      headers: {
+        authorization: `DPoP ${accessToken}`,
+        dpop: dpopProof,
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe('invalid_dpop_proof');
+  });
+
+  test('should reject DPoP scheme when token has no cnf.jkt', async () => {
+    const fastify = Fastify();
+    fastify.register(fastifyAuth0Api, { domain, audience });
+
+    fastify.register(() => {
+      fastify.get('/test', { preHandler: fastify.requireAuth() }, async () => 'OK');
+    });
+
+    const accessToken = await signAccessToken();
+    const dpopProof = await createDpopProof(accessToken, 'GET', 'http://localhost:80/test');
+
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/test',
+      headers: {
+        authorization: `DPoP ${accessToken}`,
+        dpop: dpopProof,
+      },
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.json().error).toBe('invalid_token');
+  });
+
+  test('should include WWW-Authenticate with DPoP challenge', async () => {
+    const fastify = Fastify();
+    fastify.register(fastifyAuth0Api, { domain, audience });
+
+    fastify.register(() => {
+      fastify.get('/test', { preHandler: fastify.requireAuth() }, async () => 'OK');
+    });
+
+    const accessToken = await signAccessToken({ cnfJkt: ecThumbprint });
+    const dpopProof = await createDpopProof(accessToken, 'GET', 'http://localhost:80/test', { invalidAth: true });
+
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/test',
+      headers: {
+        authorization: `DPoP ${accessToken}`,
+        dpop: dpopProof,
+      },
+    });
+
+    const wwwAuth = res.headers['www-authenticate'];
+    expect(wwwAuth).toBeDefined();
+    expect(String(wwwAuth)).toMatch(/DPoP/);
+    expect(String(wwwAuth)).toMatch(/algs="ES256"/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DPoP mode: 'required'
+// ---------------------------------------------------------------------------
+
+describe('DPoP mode: required', () => {
+  test('should reject Bearer token when DPoP is required', async () => {
+    const fastify = Fastify();
+    fastify.register(fastifyAuth0Api, { domain, audience, dpop: { mode: 'required' } });
+
+    fastify.register(() => {
+      fastify.get('/test', { preHandler: fastify.requireAuth() }, async () => 'OK');
+    });
+
+    const accessToken = await signAccessToken();
+
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/test',
+      headers: { authorization: `Bearer ${accessToken}` },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe('invalid_request');
+    const wwwAuth = res.headers['www-authenticate'];
+    expect(wwwAuth).toBeDefined();
+    expect(String(wwwAuth)).toMatch(/DPoP/);
+    expect(String(wwwAuth)).toMatch(/algs="ES256"/);
+  });
+
+  test('should accept valid DPoP token when DPoP is required', async () => {
+    const fastify = Fastify();
+    fastify.register(fastifyAuth0Api, { domain, audience, dpop: { mode: 'required' } });
+
+    fastify.register(() => {
+      fastify.get('/test', { preHandler: fastify.requireAuth() }, async () => 'OK');
+    });
+
+    const accessToken = await signAccessToken({ cnfJkt: ecThumbprint });
+    const dpopProof = await createDpopProof(accessToken, 'GET', 'http://localhost:80/test');
+
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/test',
+      headers: {
+        authorization: `DPoP ${accessToken}`,
+        dpop: dpopProof,
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBe('OK');
+  });
+
+  test('should reject DPoP scheme without proof when DPoP is required', async () => {
+    const fastify = Fastify();
+    fastify.register(fastifyAuth0Api, { domain, audience, dpop: { mode: 'required' } });
+
+    fastify.register(() => {
+      fastify.get('/test', { preHandler: fastify.requireAuth() }, async () => 'OK');
+    });
+
+    const accessToken = await signAccessToken({ cnfJkt: ecThumbprint });
+
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/test',
+      headers: { authorization: `DPoP ${accessToken}` },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe('invalid_request');
+  });
+
+  test('should only include DPoP challenge (not Bearer) when mode is required', async () => {
+    const fastify = Fastify();
+    fastify.register(fastifyAuth0Api, { domain, audience, dpop: { mode: 'required' } });
+
+    fastify.register(() => {
+      fastify.get('/test', { preHandler: fastify.requireAuth() }, async () => 'OK');
+    });
+
+    const accessToken = await signAccessToken();
+
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/test',
+      headers: { authorization: `Bearer ${accessToken}` },
+    });
+
+    const wwwAuth = String(res.headers['www-authenticate']);
+    expect(wwwAuth).toMatch(/DPoP/);
+    expect(wwwAuth).not.toMatch(/Bearer realm=/);
+  });
+
+  test('should reject invalid DPoP proof when mode is required', async () => {
+    const fastify = Fastify();
+    fastify.register(fastifyAuth0Api, { domain, audience, dpop: { mode: 'required' } });
+
+    fastify.register(() => {
+      fastify.get('/test', { preHandler: fastify.requireAuth() }, async () => 'OK');
+    });
+
+    const accessToken = await signAccessToken({ cnfJkt: ecThumbprint });
+    const dpopProof = await createDpopProof(accessToken, 'GET', 'http://localhost:80/test', { invalidAth: true });
+
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/test',
+      headers: {
+        authorization: `DPoP ${accessToken}`,
+        dpop: dpopProof,
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe('invalid_dpop_proof');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DPoP mode: 'disabled'
+// ---------------------------------------------------------------------------
+
+describe('DPoP mode: disabled', () => {
+  test('should accept Bearer token when DPoP is disabled', async () => {
+    const fastify = Fastify();
+    fastify.register(fastifyAuth0Api, { domain, audience, dpop: { mode: 'disabled' } });
+
+    fastify.register(() => {
+      fastify.get('/test', { preHandler: fastify.requireAuth() }, async () => 'OK');
+    });
+
+    const accessToken = await signAccessToken();
+
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/test',
+      headers: { authorization: `Bearer ${accessToken}` },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBe('OK');
+  });
+
+  test('should reject DPoP scheme when DPoP is disabled', async () => {
+    const fastify = Fastify();
+    fastify.register(fastifyAuth0Api, { domain, audience, dpop: { mode: 'disabled' } });
+
+    fastify.register(() => {
+      fastify.get('/test', { preHandler: fastify.requireAuth() }, async () => 'OK');
+    });
+
+    const accessToken = await signAccessToken({ cnfJkt: ecThumbprint });
+    const dpopProof = await createDpopProof(accessToken, 'GET', 'http://localhost:80/test');
+
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/test',
+      headers: {
+        authorization: `DPoP ${accessToken}`,
+        dpop: dpopProof,
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe('invalid_request');
+  });
+
+  test('should only include Bearer challenge (not DPoP) when mode is disabled', async () => {
+    const fastify = Fastify();
+    fastify.register(fastifyAuth0Api, { domain, audience, dpop: { mode: 'disabled' } });
+
+    fastify.register(() => {
+      fastify.get('/test', { preHandler: fastify.requireAuth() }, async () => 'OK');
+    });
+
+    const accessToken = await signAccessToken({ cnfJkt: ecThumbprint });
+    const dpopProof = await createDpopProof(accessToken, 'GET', 'http://localhost:80/test');
+
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/test',
+      headers: {
+        authorization: `DPoP ${accessToken}`,
+        dpop: dpopProof,
+      },
+    });
+
+    const wwwAuth = String(res.headers['www-authenticate']);
+    expect(wwwAuth).toMatch(/Bearer/);
+    expect(wwwAuth).not.toMatch(/DPoP algs=/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DPoP proof validation details
+// ---------------------------------------------------------------------------
+
+describe('DPoP proof validation', () => {
+  test('should reject proof with wrong HTTP method', async () => {
+    const fastify = Fastify();
+    fastify.register(fastifyAuth0Api, { domain, audience });
+
+    fastify.register(() => {
+      fastify.post('/test', { preHandler: fastify.requireAuth() }, async () => 'OK');
+    });
+
+    const accessToken = await signAccessToken({ cnfJkt: ecThumbprint });
+    const dpopProof = await createDpopProof(accessToken, 'GET', 'http://localhost:80/test');
+
+    const res = await fastify.inject({
+      method: 'POST',
+      url: '/test',
+      headers: {
+        authorization: `DPoP ${accessToken}`,
+        dpop: dpopProof,
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe('invalid_dpop_proof');
+  });
+
+  test('should reject proof with wrong URL', async () => {
+    const fastify = Fastify();
+    fastify.register(fastifyAuth0Api, { domain, audience });
+
+    fastify.register(() => {
+      fastify.get('/correct-path', { preHandler: fastify.requireAuth() }, async () => 'OK');
+    });
+
+    const accessToken = await signAccessToken({ cnfJkt: ecThumbprint });
+    const dpopProof = await createDpopProof(accessToken, 'GET', 'http://localhost:80/wrong-path');
+
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/correct-path',
+      headers: {
+        authorization: `DPoP ${accessToken}`,
+        dpop: dpopProof,
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe('invalid_dpop_proof');
+  });
+
+  test('should reject proof with expired iat', async () => {
+    const fastify = Fastify();
+    fastify.register(fastifyAuth0Api, { domain, audience, dpop: { iatOffset: 60 } });
+
+    fastify.register(() => {
+      fastify.get('/test', { preHandler: fastify.requireAuth() }, async () => 'OK');
+    });
+
+    const accessToken = await signAccessToken({ cnfJkt: ecThumbprint });
+    const dpopProof = await createDpopProof(accessToken, 'GET', 'http://localhost:80/test', { expiredIat: true });
+
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/test',
+      headers: {
+        authorization: `DPoP ${accessToken}`,
+        dpop: dpopProof,
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe('invalid_dpop_proof');
+  });
+
+  test('should validate proof with custom iatOffset and iatLeeway', async () => {
+    const fastify = Fastify();
+    fastify.register(fastifyAuth0Api, { domain, audience, dpop: { iatOffset: 700, iatLeeway: 60 } });
+
+    fastify.register(() => {
+      fastify.get('/test', { preHandler: fastify.requireAuth() }, async () => 'OK');
+    });
+
+    const accessToken = await signAccessToken({ cnfJkt: ecThumbprint });
+    const dpopProof = await createDpopProof(accessToken, 'GET', 'http://localhost:80/test', { expiredIat: true });
+
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/test',
+      headers: {
+        authorization: `DPoP ${accessToken}`,
+        dpop: dpopProof,
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBe('OK');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DPoP with scope validation
+// ---------------------------------------------------------------------------
+
+describe('DPoP with scope validation', () => {
+  test('should enforce scopes with DPoP-bound tokens', async () => {
+    const fastify = Fastify();
+    fastify.register(fastifyAuth0Api, { domain, audience });
+
+    fastify.register(() => {
+      fastify.get('/test', { preHandler: fastify.requireAuth({ scopes: 'admin:write' }) }, async () => 'OK');
+    });
+
+    const accessToken = await signAccessToken({ cnfJkt: ecThumbprint, claims: { scope: 'read:data' } });
+    const dpopProof = await createDpopProof(accessToken, 'GET', 'http://localhost:80/test');
+
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/test',
+      headers: {
+        authorization: `DPoP ${accessToken}`,
+        dpop: dpopProof,
+      },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(res.json().error).toBe('insufficient_scope');
+  });
+
+  test('should pass scope validation with DPoP-bound tokens', async () => {
+    const fastify = Fastify();
+    fastify.register(fastifyAuth0Api, { domain, audience });
+
+    fastify.register(() => {
+      fastify.get('/test', { preHandler: fastify.requireAuth({ scopes: 'read:data' }) }, async () => 'OK');
+    });
+
+    const accessToken = await signAccessToken({ cnfJkt: ecThumbprint, claims: { scope: 'read:data write:data' } });
+    const dpopProof = await createDpopProof(accessToken, 'GET', 'http://localhost:80/test');
+
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/test',
+      headers: {
+        authorization: `DPoP ${accessToken}`,
+        dpop: dpopProof,
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBe('OK');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DPoP with Multiple Custom Domains
+// ---------------------------------------------------------------------------
+
+describe('DPoP with Multiple Custom Domains', () => {
+  test('should validate DPoP with domains allowlist', async () => {
+    const fastify = Fastify();
+    fastify.register(fastifyAuth0Api, { audience, domains: [domain] });
+
+    fastify.register(() => {
+      fastify.get('/test', { preHandler: fastify.requireAuth() }, async () => 'OK');
+    });
+
+    const accessToken = await signAccessToken({ cnfJkt: ecThumbprint });
+    const dpopProof = await createDpopProof(accessToken, 'GET', 'http://localhost:80/test');
+
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/test',
+      headers: {
+        authorization: `DPoP ${accessToken}`,
+        dpop: dpopProof,
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBe('OK');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getToken() with DPoP scheme
+// ---------------------------------------------------------------------------
+
+describe('getToken() with DPoP scheme', () => {
+  test('should extract token from DPoP Authorization header', async () => {
+    const fastify = Fastify();
+    fastify.register(fastifyAuth0Api, { domain, audience });
+
+    let extractedToken: string | undefined;
+
+    fastify.register(() => {
+      fastify.get('/test', { preHandler: fastify.requireAuth() }, async (request) => {
+        extractedToken = request.getToken();
+        return 'OK';
+      });
+    });
+
+    const accessToken = await signAccessToken({ cnfJkt: ecThumbprint });
+    const dpopProof = await createDpopProof(accessToken, 'GET', 'http://localhost:80/test');
+
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/test',
+      headers: {
+        authorization: `DPoP ${accessToken}`,
+        dpop: dpopProof,
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(extractedToken).toBe(accessToken);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error class exports
+// ---------------------------------------------------------------------------
+
+describe('DPoP error class exports', () => {
+  test('InvalidDpopProofError is exported', () => {
+    expect(InvalidDpopProofError).toBeDefined();
+    const err = new InvalidDpopProofError('test');
+    expect(err.code).toBe('invalid_dpop_proof');
+    expect(err.statusCode).toBe(400);
+  });
+
+  test('InvalidRequestError is exported', () => {
+    expect(InvalidRequestError).toBeDefined();
+    const err = new InvalidRequestError('test');
+    expect(err.code).toBe('invalid_request');
+    expect(err.statusCode).toBe(400);
+  });
+
+  test('VerifyAccessTokenError is exported', () => {
+    expect(VerifyAccessTokenError).toBeDefined();
+    const err = new VerifyAccessTokenError('test');
+    expect(err.code).toBe('verify_access_token_error');
+    expect(err.statusCode).toBe(401);
+  });
+});

--- a/packages/auth0-fastify-api/src/index.ts
+++ b/packages/auth0-fastify-api/src/index.ts
@@ -213,6 +213,15 @@ async function auth0FastifyApi(fastify: FastifyInstance, options: Auth0FastifyAp
         const httpUrl = buildRequestUrl(request);
         const dpopProof = extractDpopProof(request);
 
+        if (dpopProof && !httpUrl) {
+          return replyWithError(
+            reply,
+            400,
+            'invalid_request',
+            'Unable to construct request URL for DPoP validation. Ensure trustProxy is configured if behind a proxy.'
+          );
+        }
+
         const verifyOptions: VerifyAccessTokenOptions = dpopProof
           ? {
               accessToken,

--- a/packages/auth0-fastify-api/src/index.ts
+++ b/packages/auth0-fastify-api/src/index.ts
@@ -4,9 +4,11 @@ import fp from 'fastify-plugin';
 import {
   ApiClient,
   type ApiClientOptions,
+  type DPoPOptions,
   type DiscoveryCacheOptions,
   type DomainsResolver,
   type VerifyAccessTokenOptions,
+  AuthError,
 } from '@auth0/auth0-api-js';
 
 export type AuthRouteOptions = {
@@ -68,6 +70,14 @@ type Auth0FastifyApiCommonOptions = {
    * TTL is in seconds. Defaults to the ApiClient defaults when omitted.
    */
   discoveryCache?: DiscoveryCacheOptions;
+  /**
+   * Optional DPoP (Demonstration of Proof-of-Possession) configuration.
+   *
+   * - `mode: 'allowed'` (default): accepts both Bearer and DPoP-bound tokens.
+   * - `mode: 'required'`: only DPoP-bound tokens are accepted.
+   * - `mode: 'disabled'`: DPoP is ignored; Bearer-only behavior.
+   */
+  dpop?: DPoPOptions;
 };
 
 export type Auth0FastifyApiOptions =
@@ -128,6 +138,7 @@ type ApiClientBaseOptions = {
   algorithms?: ApiClientOptions['algorithms'];
   customFetch?: ApiClientOptions['customFetch'];
   discoveryCache?: ApiClientOptions['discoveryCache'];
+  dpop?: ApiClientOptions['dpop'];
 };
 
 async function auth0FastifyApi(fastify: FastifyInstance, options: Auth0FastifyApiOptions) {
@@ -140,6 +151,7 @@ async function auth0FastifyApi(fastify: FastifyInstance, options: Auth0FastifyAp
     algorithms: options.algorithms,
     customFetch: options.customFetch,
     discoveryCache: options.discoveryCache,
+    dpop: options.dpop,
   };
 
   const clientOptions: ApiClientOptions = hasDomain(options)
@@ -159,36 +171,67 @@ async function auth0FastifyApi(fastify: FastifyInstance, options: Auth0FastifyAp
 
   const apiClient = new ApiClient(clientOptions);
 
-  const replyWithError = (reply: FastifyReply, statusCode: number, error: string, errorDescription: string) => {
-    return reply
-      .code(statusCode)
-      .header(
+  const replyWithError = (
+    reply: FastifyReply,
+    statusCode: number,
+    error: string,
+    errorDescription: string,
+    headers?: Record<string, string | string[]>
+  ) => {
+    if (headers) {
+      for (const [key, value] of Object.entries(headers)) {
+        if (Array.isArray(value)) {
+          for (const v of value) {
+            reply.header(key, v);
+          }
+        } else {
+          reply.header(key, value);
+        }
+      }
+    } else {
+      reply.header(
         'WWW-Authenticate',
         `Bearer error="${error.replaceAll('"', '\\"')}", error_description="${errorDescription.replaceAll('"', '\\"')}"`
-      )
-      .send({
-        error: error,
-        error_description: errorDescription,
-      });
+      );
+    }
+
+    return reply.code(statusCode).send({
+      error: error,
+      error_description: errorDescription,
+    });
   };
 
   fastify.decorate('requireAuth', function (opts: AuthRouteOptions = {}) {
     return async function (request: FastifyRequest, reply: FastifyReply) {
-      const accessToken = getToken(request);
+      const { accessToken, scheme } = extractToken(request);
 
       if (!accessToken) {
         return replyWithError(reply, 400, 'invalid_request', 'No Authorization provided');
       }
 
       try {
-        const verifyOptions: VerifyAccessTokenOptions = options.domains
+        const httpUrl = buildRequestUrl(request);
+        const dpopProof = extractDpopProof(request);
+
+        const verifyOptions: VerifyAccessTokenOptions = dpopProof
           ? {
               accessToken,
-              httpUrl: buildRequestUrl(request),
+              scheme,
+              dpopProof,
+              httpMethod: request.method,
+              httpUrl: httpUrl!,
+              headers: request.headers as Record<string, string | string[] | undefined>,
+            }
+          : options.domains
+          ? {
+              accessToken,
+              scheme,
+              httpUrl,
               headers: request.headers as Record<string, string | string[] | undefined>,
             }
           : {
               accessToken,
+              scheme,
             };
 
         const token = (await apiClient.verifyAccessToken(verifyOptions)) as Token;
@@ -199,10 +242,17 @@ async function auth0FastifyApi(fastify: FastifyInstance, options: Auth0FastifyAp
 
         request['user'] = token;
       } catch (error) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        if ((error as any).code === 'verify_access_token_error') {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          return replyWithError(reply, 401, 'invalid_token', (error as any).message);
+        if (error instanceof AuthError) {
+          const statusCode = error.statusCode ?? 401;
+          const errorCode =
+            error.code === 'verify_access_token_error'
+              ? 'invalid_token'
+              : error.code === 'invalid_dpop_proof'
+              ? 'invalid_dpop_proof'
+              : error.code === 'invalid_request'
+              ? 'invalid_request'
+              : 'invalid_token';
+          return replyWithError(reply, statusCode, errorCode, error.message, error.headers);
         }
 
         return replyWithError(reply, 401, 'invalid_token', 'Invalid token');
@@ -219,10 +269,29 @@ async function auth0FastifyApi(fastify: FastifyInstance, options: Auth0FastifyAp
 
 export default fp(auth0FastifyApi);
 
-function getToken(request: FastifyRequest): string | undefined {
+function extractToken(request: FastifyRequest): { accessToken: string | undefined; scheme: string } {
   const parts = request.headers.authorization?.split(' ');
 
-  return parts?.length === 2 && parts[0]?.toLowerCase() === 'bearer' ? parts[1] : undefined;
+  if (parts?.length === 2) {
+    const scheme = parts[0]!.toLowerCase();
+    if (scheme === 'bearer' || scheme === 'dpop') {
+      return { accessToken: parts[1], scheme };
+    }
+  }
+
+  return { accessToken: undefined, scheme: 'bearer' };
+}
+
+function getToken(request: FastifyRequest): string | undefined {
+  return extractToken(request).accessToken;
+}
+
+function extractDpopProof(request: FastifyRequest): string | undefined {
+  const value = request.headers['dpop'];
+  if (typeof value === 'string' && value.length > 0) {
+    return value;
+  }
+  return undefined;
 }
 
 function buildRequestUrl(request: FastifyRequest): string | undefined {
@@ -234,9 +303,18 @@ function buildRequestUrl(request: FastifyRequest): string | undefined {
 }
 
 export type {
+  DPoPOptions,
   DomainsResolver,
   DomainsResolverContext,
   OnBehalfOfTokenOptions,
   OnBehalfOfTokenResult,
 } from '@auth0/auth0-api-js';
-export { getCurrentActor, getDelegationChain, MissingClientAuthError, TokenExchangeError } from '@auth0/auth0-api-js';
+export {
+  getCurrentActor,
+  getDelegationChain,
+  InvalidDpopProofError,
+  InvalidRequestError,
+  MissingClientAuthError,
+  TokenExchangeError,
+  VerifyAccessTokenError,
+} from '@auth0/auth0-api-js';


### PR DESCRIPTION
### Summary
Adds [DPoP (Demonstration of Proof-of-Possession, RFC 9449)](https://datatracker.ietf.org/doc/html/rfc9449) support to `@auth0/auth0-fastify-api`. DPoP binds access tokens to a client's key pair, preventing stolen tokens from being replayed by attackers.

The SDK now automatically extracts the `DPoP` proof header, detects the authorization scheme (`Bearer` vs `DPoP`), and delegates full cryptographic validation to the underlying `@auth0/auth0-api-js` SDK.

### Changes
- Plugin configuration: Added `dpop` option with mode (`allowed` | `required` | `disabled`), `iatOffset`, and `iatLeeway` settings.
- Token extraction: Recognizes both `Authorization: Bearer <token>` and `Authorization: DPoP <token> `schemes.
- `DPoP` proof forwarding: Extracts the `DPoP` request header and passes it along with `httpMethod`, `httpUrl`, and scheme to `ApiClient.verifyAccessToken()`.
- Error handling: Properly surfaces `InvalidDpopProofError` (400), `InvalidRequestError` (400), and `VerifyAccessTokenError` (401) with RFC-compliant `WWW-Authenticate` challenge headers.
- Exports: Re-exports `DPoPOptions`, `InvalidDpopProofError`, `InvalidRequestError`, and `VerifyAccessTokenError` for consumer error handling.
- Documentation: Added `DPoP` sections to both `README.md` and `EXAMPLES.md` covering configuration, modes, error handling, timing, and `MCD` integration.

### Configuration
```ts
fastify.register(fastifyAuth0Api, {
  domain: '<AUTH0_DOMAIN>',
  audience: '<AUTH0_AUDIENCE>',
  dpop: {
    mode: 'required',        // 'allowed' (default) | 'required' | 'disabled'
    iatOffset: 300,          // optional, default: 300
    iatLeeway: 30,           // optional, default: 30
  },
});
```