### PR TITLE
fix(auth0-fastify-api): fix the package version

### DIFF
--- a/packages/auth0-fastify-api/package.json
+++ b/packages/auth0-fastify-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth0/auth0-fastify-api",
-  "version": "1.3.0",
+  "version": "1.2.0",
   "description": "Auth0 SDK for Fastify API's on JavaScript runtimes",
   "author": "Auth0",
   "license": "MIT",


### PR DESCRIPTION
### Changes
`version` in the `package.json` file was mistakenly bumped up in https://github.com/auth0/auth0-fastify/pull/58.
Reverting the version