### PR TITLE
chore: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  # npm workspaces monorepo — the root manifest covers all packages and examples
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      npm-development:
+        dependency-type: "development"
+      npm-production:
+        dependency-type: "production"
+
+  # Keep GitHub Actions used by the workflows up to date
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
     groups:
       npm-development:
         dependency-type: "development"
@@ -18,3 +21,5 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(ci)"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` to enable automated dependency updates. The repo currently has no Dependabot/Renovate config.

Two ecosystems, both weekly:
- **npm** at `/` — npm workspaces monorepo, so the root manifest covers all packages and examples. Grouped into production / development updates. PR limit 10.
- **github-actions** at `/` — keeps the actions used by the 3 workflows current. PR limit 5.

Dependabot commit messages are prefixed (`chore(deps)` / `chore(deps-dev)` / `chore(ci)`) to match the repo's conventional-commit style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)