### PR TITLE
docs: add agentic discoverability files (AGENTS.md, llms.txt, CLAUDE.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,17 +4,16 @@ Guidance for AI coding agents working in this repository.
 
 ## What this is
 
-A monorepo containing two published SDKs for adding Auth0 to Fastify (v5+)
-applications on JavaScript runtimes. Both packages are TypeScript and require
-Node.js 20 LTS or newer.
+A monorepo containing two published TypeScript SDKs for adding Auth0 to Fastify
+(v5+) applications. Requires Node.js 20 LTS or newer.
 
-| Package | Path | Purpose |
-|---------|------|---------|
-| `@auth0/auth0-fastify` | `packages/auth0-fastify` | User authentication for server-rendered web apps: registers a Fastify plugin, mounts login/logout/callback routes, manages encrypted session cookies, protects routes, supports account linking. Built on `@auth0/auth0-server-js`. |
-| `@auth0/auth0-fastify-api` | `packages/auth0-fastify-api` | API protection: validates bearer access tokens (RS256; HS* rejected), enforces audience/scopes, supports DPoP and On-Behalf-Of token exchange. Built on `@auth0/auth0-api-js`. |
+| Package | Path | What it is | Built on |
+|---------|------|-----------|----------|
+| `@auth0/auth0-fastify` | `packages/auth0-fastify` | Web app authentication SDK | `@auth0/auth0-server-js` |
+| `@auth0/auth0-fastify-api` | `packages/auth0-fastify-api` | API protection SDK | `@auth0/auth0-api-js` |
 
-Runnable examples live in `examples/example-fastify-web` and
-`examples/example-fastify-api`.
+For what each SDK does and how to use it, see the package `README.md` and
+`EXAMPLES.md`.
 
 ## Layout
 
@@ -55,16 +54,9 @@ keep changes compatible with both.
 - **Keep packages independent.** A change to the web package must not require a
   change to the API package unless intentional; they ship separately and are
   versioned independently.
-- **Security defaults matter.** RS256 is the default for access-token
-  validation and HS* algorithms are rejected; encrypted session cookies require
-  a `sessionSecret`. Do not weaken these defaults.
-- **Secrets via environment variables.** Values such as `clientSecret` and
-  `sessionSecret` must come from environment variables (as the examples do),
-  never hard-coded in source.
-- **Reverse-proxy awareness.** `inferAppBaseUrlFromRequest` in
-  `packages/auth0-fastify/src/index.ts` reads `x-forwarded-host` /
-  `x-forwarded-proto`. Only rely on those behind a trusted proxy
-  (`fastify.trustProxy`).
+- **Don't weaken security defaults when editing.** Token validation defaults to
+  RS256 and rejects HS* algorithms; session cookies are encrypted and require a
+  `sessionSecret`. Preserve these when modifying the relevant code.
 - **Add tests** for behavior changes (`*.spec.ts` beside the source) and keep
   `npm run lint` clean before considering work done.
 - **Conventional commits.** Match the existing history (`feat(scope):`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,9 @@ keep changes compatible with both.
 - **Security defaults matter.** RS256 is the default for access-token
   validation and HS* algorithms are rejected; encrypted session cookies require
   a `sessionSecret`. Do not weaken these defaults.
+- **Secrets via environment variables.** Values such as `clientSecret` and
+  `sessionSecret` must come from environment variables (as the examples do),
+  never hard-coded in source.
 - **Reverse-proxy awareness.** `inferAppBaseUrlFromRequest` in
   `packages/auth0-fastify/src/index.ts` reads `x-forwarded-host` /
   `x-forwarded-proto`. Only rely on those behind a trusted proxy

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,70 @@
+# AGENTS.md
+
+Onboarding for AI agents integrating Auth0 into a Fastify application using the
+SDKs in this monorepo. For working *on* this repo (build/test/conventions), see
+[CLAUDE.md](./CLAUDE.md).
+
+## Pick the right package
+
+| Your app is… | Use | Install |
+|--------------|-----|---------|
+| A server-rendered Fastify **web app** that logs users in and keeps a session | `@auth0/auth0-fastify` | `npm i @auth0/auth0-fastify` |
+| A Fastify **API** that validates access tokens from callers | `@auth0/auth0-fastify-api` | `npm i @auth0/auth0-fastify-api` |
+| Both (web app + separate API) | both packages | install both |
+
+Requirements: Node.js 20 LTS+ and Fastify v5+.
+
+## Web app — `@auth0/auth0-fastify`
+
+Registers a Fastify plugin that mounts login, logout, and callback routes, and
+stores an encrypted session cookie. Minimum configuration:
+
+- `domain` — your Auth0 tenant domain.
+- `clientId` / `clientSecret` — from your Auth0 Regular Web Application.
+- `appBaseUrl` — the public base URL of your app.
+- `sessionSecret` — secret used to encrypt the session cookie.
+
+After registering, protect routes and read the authenticated user from the
+session. Account linking, custom routes, interactive login without mounted
+routes, backchannel logout, pushed authorization requests, and external session
+stores are covered in
+[packages/auth0-fastify/EXAMPLES.md](./packages/auth0-fastify/EXAMPLES.md).
+Start from [packages/auth0-fastify/README.md](./packages/auth0-fastify/README.md).
+
+## API — `@auth0/auth0-fastify-api`
+
+Registers a plugin that validates incoming bearer access tokens against your
+Auth0 tenant. Minimum configuration:
+
+- `domain` — your Auth0 tenant domain.
+- `audience` — the API identifier the token must be issued for.
+
+Defaults to RS256 and rejects HS* algorithms. Enforce scopes per route, and use
+DPoP or On-Behalf-Of token exchange where needed — see
+[packages/auth0-fastify-api/EXAMPLES.md](./packages/auth0-fastify-api/EXAMPLES.md).
+Start from
+[packages/auth0-fastify-api/README.md](./packages/auth0-fastify-api/README.md).
+
+## Guardrails when generating integration code
+
+- **Secrets come from environment variables**, never hard-coded. All official
+  examples read `clientSecret` / `sessionSecret` from env.
+- **Behind a proxy/load balancer**, set `fastify.trustProxy` so the SDK derives
+  the correct base URL from `x-forwarded-*` headers; do not trust those headers
+  on a directly-exposed app.
+- **Do not lower security defaults** (RS256, encrypted sessions).
+- **Use Fastify v5 patterns** (await plugin registration); v4 syntax will not
+  work.
+
+## Try the examples first
+
+- Web: [examples/example-fastify-web](./examples/example-fastify-web/README.md)
+- API: [examples/example-fastify-api](./examples/example-fastify-api/README.md)
+
+From the repo root: `npm install && npm run build`, then follow the example's
+README.
+
+## Official quickstarts
+
+- Web: https://auth0.com/docs/quickstart/webapp/fastify
+- API: https://auth0.com/docs/quickstart/backend/fastify

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,70 +1,75 @@
 # AGENTS.md
 
-Onboarding for AI agents integrating Auth0 into a Fastify application using the
-SDKs in this monorepo. For working *on* this repo (build/test/conventions), see
-[CLAUDE.md](./CLAUDE.md).
+Guidance for AI coding agents working in this repository.
 
-## Pick the right package
+## What this is
 
-| Your app is… | Use | Install |
-|--------------|-----|---------|
-| A server-rendered Fastify **web app** that logs users in and keeps a session | `@auth0/auth0-fastify` | `npm i @auth0/auth0-fastify` |
-| A Fastify **API** that validates access tokens from callers | `@auth0/auth0-fastify-api` | `npm i @auth0/auth0-fastify-api` |
-| Both (web app + separate API) | both packages | install both |
+A monorepo containing two published SDKs for adding Auth0 to Fastify (v5+)
+applications on JavaScript runtimes. Both packages are TypeScript and require
+Node.js 20 LTS or newer.
 
-Requirements: Node.js 20 LTS+ and Fastify v5+.
+| Package | Path | Purpose |
+|---------|------|---------|
+| `@auth0/auth0-fastify` | `packages/auth0-fastify` | User authentication for server-rendered web apps: registers a Fastify plugin, mounts login/logout/callback routes, manages encrypted session cookies, protects routes, supports account linking. Built on `@auth0/auth0-server-js`. |
+| `@auth0/auth0-fastify-api` | `packages/auth0-fastify-api` | API protection: validates bearer access tokens (RS256; HS* rejected), enforces audience/scopes, supports DPoP and On-Behalf-Of token exchange. Built on `@auth0/auth0-api-js`. |
 
-## Web app — `@auth0/auth0-fastify`
+Runnable examples live in `examples/example-fastify-web` and
+`examples/example-fastify-api`.
 
-Registers a Fastify plugin that mounts login, logout, and callback routes, and
-stores an encrypted session cookie. Minimum configuration:
+## Layout
 
-- `domain` — your Auth0 tenant domain.
-- `clientId` / `clientSecret` — from your Auth0 Regular Web Application.
-- `appBaseUrl` — the public base URL of your app.
-- `sessionSecret` — secret used to encrypt the session cookie.
+```
+packages/auth0-fastify/        # web auth SDK (source in src/, tests are *.spec.ts)
+packages/auth0-fastify-api/    # API protection SDK
+examples/                      # runnable example apps (npm workspaces)
+.github/workflows/             # CI: build, test (Node 20 & 22), Snyk SCA
+```
 
-After registering, protect routes and read the authenticated user from the
-session. Account linking, custom routes, interactive login without mounted
-routes, backchannel logout, pushed authorization requests, and external session
-stores are covered in
-[packages/auth0-fastify/EXAMPLES.md](./packages/auth0-fastify/EXAMPLES.md).
-Start from [packages/auth0-fastify/README.md](./packages/auth0-fastify/README.md).
+## Build, test, lint
 
-## API — `@auth0/auth0-fastify-api`
+This is an npm workspaces monorepo orchestrated with Turborepo. Run from the
+repo root:
 
-Registers a plugin that validates incoming bearer access tokens against your
-Auth0 tenant. Minimum configuration:
+```bash
+npm install            # install all workspace deps
+npm run build          # turbo run build (all packages)
+npm run test           # turbo run test (all packages)
+npm run lint           # turbo run lint
+npm run docs           # generate TypeDoc
+```
 
-- `domain` — your Auth0 tenant domain.
-- `audience` — the API identifier the token must be issued for.
+Target a single package with npm workspaces:
 
-Defaults to RS256 and rejects HS* algorithms. Enforce scopes per route, and use
-DPoP or On-Behalf-Of token exchange where needed — see
-[packages/auth0-fastify-api/EXAMPLES.md](./packages/auth0-fastify-api/EXAMPLES.md).
-Start from
-[packages/auth0-fastify-api/README.md](./packages/auth0-fastify-api/README.md).
+```bash
+npm run build -w @auth0/auth0-fastify
+npm run test:ci -w @auth0/auth0-fastify-api
+```
 
-## Guardrails when generating integration code
+Tests are colocated with source as `*.spec.ts`. CI runs on Node 20 and 22, so
+keep changes compatible with both.
 
-- **Secrets come from environment variables**, never hard-coded. All official
-  examples read `clientSecret` / `sessionSecret` from env.
-- **Behind a proxy/load balancer**, set `fastify.trustProxy` so the SDK derives
-  the correct base URL from `x-forwarded-*` headers; do not trust those headers
-  on a directly-exposed app.
-- **Do not lower security defaults** (RS256, encrypted sessions).
-- **Use Fastify v5 patterns** (await plugin registration); v4 syntax will not
-  work.
+## Conventions
 
-## Try the examples first
+- **TypeScript, Fastify v5+, Node 20+.** Do not introduce Fastify v4 patterns
+  (e.g. non-awaited plugin registration) — the SDKs require v5.
+- **Keep packages independent.** A change to the web package must not require a
+  change to the API package unless intentional; they ship separately and are
+  versioned independently.
+- **Security defaults matter.** RS256 is the default for access-token
+  validation and HS* algorithms are rejected; encrypted session cookies require
+  a `sessionSecret`. Do not weaken these defaults.
+- **Reverse-proxy awareness.** `inferAppBaseUrlFromRequest` in
+  `packages/auth0-fastify/src/index.ts` reads `x-forwarded-host` /
+  `x-forwarded-proto`. Only rely on those behind a trusted proxy
+  (`fastify.trustProxy`).
+- **Add tests** for behavior changes (`*.spec.ts` beside the source) and keep
+  `npm run lint` clean before considering work done.
+- **Conventional commits.** Match the existing history (`feat(scope):`,
+  `fix(scope):`, `chore(scope):`).
+- **Match existing style.** Follow the patterns already in each package rather
+  than introducing new abstractions.
 
-- Web: [examples/example-fastify-web](./examples/example-fastify-web/README.md)
-- API: [examples/example-fastify-api](./examples/example-fastify-api/README.md)
+## Where to look first
 
-From the repo root: `npm install && npm run build`, then follow the example's
-README.
-
-## Official quickstarts
-
-- Web: https://auth0.com/docs/quickstart/webapp/fastify
-- API: https://auth0.com/docs/quickstart/backend/fastify
+Read `README.md` (root), then the package `README.md` and `EXAMPLES.md` for the
+package you are touching. `llms.txt` is a structured index of the repo's docs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,1 @@
-# CLAUDE.md
-
-Instructions for AI coding agents working in this repository live in
-[AGENTS.md](./AGENTS.md). Claude Code does not read `AGENTS.md` automatically,
-so it is imported here:
-
 @AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,75 +1,7 @@
 # CLAUDE.md
 
-Guidance for coding agents (Claude Code and others) working in this repository.
+Instructions for AI coding agents working in this repository live in
+[AGENTS.md](./AGENTS.md). Claude Code does not read `AGENTS.md` automatically,
+so it is imported here:
 
-## What this is
-
-A monorepo containing two published SDKs for adding Auth0 to Fastify (v5+)
-applications on JavaScript runtimes. Both packages are TypeScript and require
-Node.js 20 LTS or newer.
-
-| Package | Path | Purpose |
-|---------|------|---------|
-| `@auth0/auth0-fastify` | `packages/auth0-fastify` | User authentication for server-rendered web apps: registers a Fastify plugin, mounts login/logout/callback routes, manages encrypted session cookies, protects routes, supports account linking. Built on `@auth0/auth0-server-js`. |
-| `@auth0/auth0-fastify-api` | `packages/auth0-fastify-api` | API protection: validates bearer access tokens (RS256; HS* rejected), enforces audience/scopes, supports DPoP and On-Behalf-Of token exchange. Built on `@auth0/auth0-api-js`. |
-
-Runnable examples live in `examples/example-fastify-web` and
-`examples/example-fastify-api`.
-
-## Layout
-
-```
-packages/auth0-fastify/        # web auth SDK (source in src/, tests are *.spec.ts)
-packages/auth0-fastify-api/    # API protection SDK
-examples/                      # runnable example apps (npm workspaces)
-.github/workflows/             # CI: build, test (Node 20 & 22), Snyk SCA
-```
-
-## Build, test, lint
-
-This is an npm workspaces monorepo orchestrated with Turborepo. Run from the
-repo root:
-
-```bash
-npm install            # install all workspace deps
-npm run build          # turbo run build (all packages)
-npm run test           # turbo run test (all packages)
-npm run lint           # turbo run lint
-npm run docs           # generate TypeDoc
-```
-
-Target a single package with npm workspaces:
-
-```bash
-npm run build -w @auth0/auth0-fastify
-npm run test:ci -w @auth0/auth0-fastify-api
-```
-
-Tests are colocated with source as `*.spec.ts`. CI runs on Node 20 and 22, so
-keep changes compatible with both.
-
-## Conventions
-
-- **TypeScript, Fastify v5+, Node 20+.** Do not introduce Fastify v4 patterns
-  (e.g. non-awaited plugin registration) — the SDKs require v5.
-- **Keep packages independent.** A change to the web package must not require a
-  change to the API package unless intentional; they ship separately and are
-  versioned independently.
-- **Security defaults matter.** RS256 is the default for access-token
-  validation and HS* algorithms are rejected; encrypted session cookies require
-  a `sessionSecret`. Do not weaken these defaults.
-- **Reverse-proxy awareness.** `inferAppBaseUrlFromRequest` in
-  `packages/auth0-fastify/src/index.ts` reads `x-forwarded-host` /
-  `x-forwarded-proto`. Only rely on those behind a trusted proxy
-  (`fastify.trustProxy`).
-- **Add tests** for behavior changes (`*.spec.ts` beside the source) and keep
-  `npm run lint` clean before considering work done.
-- **Match existing style.** Follow the patterns already in each package rather
-  than introducing new abstractions.
-
-## Where to look first
-
-- New to the SDKs? Read `README.md` (root), then the package `README.md` and
-  `EXAMPLES.md` for the package you are touching.
-- Integrating, not modifying? See `AGENTS.md` for how to choose and wire up the
-  right package.
+@AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,75 @@
+# CLAUDE.md
+
+Guidance for coding agents (Claude Code and others) working in this repository.
+
+## What this is
+
+A monorepo containing two published SDKs for adding Auth0 to Fastify (v5+)
+applications on JavaScript runtimes. Both packages are TypeScript and require
+Node.js 20 LTS or newer.
+
+| Package | Path | Purpose |
+|---------|------|---------|
+| `@auth0/auth0-fastify` | `packages/auth0-fastify` | User authentication for server-rendered web apps: registers a Fastify plugin, mounts login/logout/callback routes, manages encrypted session cookies, protects routes, supports account linking. Built on `@auth0/auth0-server-js`. |
+| `@auth0/auth0-fastify-api` | `packages/auth0-fastify-api` | API protection: validates bearer access tokens (RS256; HS* rejected), enforces audience/scopes, supports DPoP and On-Behalf-Of token exchange. Built on `@auth0/auth0-api-js`. |
+
+Runnable examples live in `examples/example-fastify-web` and
+`examples/example-fastify-api`.
+
+## Layout
+
+```
+packages/auth0-fastify/        # web auth SDK (source in src/, tests are *.spec.ts)
+packages/auth0-fastify-api/    # API protection SDK
+examples/                      # runnable example apps (npm workspaces)
+.github/workflows/             # CI: build, test (Node 20 & 22), Snyk SCA
+```
+
+## Build, test, lint
+
+This is an npm workspaces monorepo orchestrated with Turborepo. Run from the
+repo root:
+
+```bash
+npm install            # install all workspace deps
+npm run build          # turbo run build (all packages)
+npm run test           # turbo run test (all packages)
+npm run lint           # turbo run lint
+npm run docs           # generate TypeDoc
+```
+
+Target a single package with npm workspaces:
+
+```bash
+npm run build -w @auth0/auth0-fastify
+npm run test:ci -w @auth0/auth0-fastify-api
+```
+
+Tests are colocated with source as `*.spec.ts`. CI runs on Node 20 and 22, so
+keep changes compatible with both.
+
+## Conventions
+
+- **TypeScript, Fastify v5+, Node 20+.** Do not introduce Fastify v4 patterns
+  (e.g. non-awaited plugin registration) — the SDKs require v5.
+- **Keep packages independent.** A change to the web package must not require a
+  change to the API package unless intentional; they ship separately and are
+  versioned independently.
+- **Security defaults matter.** RS256 is the default for access-token
+  validation and HS* algorithms are rejected; encrypted session cookies require
+  a `sessionSecret`. Do not weaken these defaults.
+- **Reverse-proxy awareness.** `inferAppBaseUrlFromRequest` in
+  `packages/auth0-fastify/src/index.ts` reads `x-forwarded-host` /
+  `x-forwarded-proto`. Only rely on those behind a trusted proxy
+  (`fastify.trustProxy`).
+- **Add tests** for behavior changes (`*.spec.ts` beside the source) and keep
+  `npm run lint` clean before considering work done.
+- **Match existing style.** Follow the patterns already in each package rather
+  than introducing new abstractions.
+
+## Where to look first
+
+- New to the SDKs? Read `README.md` (root), then the package `README.md` and
+  `EXAMPLES.md` for the package you are touching.
+- Integrating, not modifying? See `AGENTS.md` for how to choose and wire up the
+  right package.

--- a/llms.txt
+++ b/llms.txt
@@ -5,9 +5,9 @@
 ## Packages
 
 - [@auth0/auth0-fastify README](./packages/auth0-fastify/README.md): Web authentication SDK — registers a Fastify plugin, mounts login/logout/callback routes, manages encrypted session cookies, protects routes, and supports account linking.
-- [@auth0/auth0-fastify README — Examples](./packages/auth0-fastify/EXAMPLES.md): Advanced web patterns — account linking (connect/unconnect), custom routes, interactive login without mounted routes, backchannel logout, pushed authorization requests, and external session stores.
+- [@auth0/auth0-fastify — Examples](./packages/auth0-fastify/EXAMPLES.md): Advanced web patterns — account linking (connect/unconnect), custom routes, interactive login without mounted routes, backchannel logout, pushed authorization requests, and external session stores.
 - [@auth0/auth0-fastify-api README](./packages/auth0-fastify-api/README.md): API protection SDK — validates bearer access tokens (RS256, rejects HS*), enforces audience/scopes, and supports DPoP.
-- [@auth0/auth0-fastify-api README — Examples](./packages/auth0-fastify-api/EXAMPLES.md): Advanced API patterns — DPoP modes, On-Behalf-Of token exchange, and multi-domain configuration.
+- [@auth0/auth0-fastify-api — Examples](./packages/auth0-fastify-api/EXAMPLES.md): Advanced API patterns — DPoP modes, On-Behalf-Of token exchange, and multi-domain configuration.
 
 ## Getting started
 

--- a/llms.txt
+++ b/llms.txt
@@ -17,8 +17,8 @@
 
 ## Development
 
-- [CLAUDE.md](./CLAUDE.md): Repository guide for coding agents — layout, build/test/lint commands, and conventions.
-- [AGENTS.md](./AGENTS.md): Agent onboarding — how to choose the right package and integrate it.
+- [AGENTS.md](./AGENTS.md): Guide for AI coding agents developing on this repo — layout, build/test/lint commands, and conventions.
+- [CLAUDE.md](./CLAUDE.md): Claude Code entry point; imports AGENTS.md (Claude Code does not read AGENTS.md automatically).
 
 ## Optional
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,28 @@
+# Auth0 Fastify SDKs
+
+> Monorepo containing two SDKs for adding Auth0 to Fastify applications: `@auth0/auth0-fastify` for user authentication in server-rendered web apps (session cookies, login/logout, route protection, account linking), and `@auth0/auth0-fastify-api` for protecting Fastify APIs (JWT access-token validation, DPoP, On-Behalf-Of token exchange). Both are TypeScript, require Node.js 20 LTS or newer, and target Fastify v5+.
+
+## Packages
+
+- [@auth0/auth0-fastify README](./packages/auth0-fastify/README.md): Web authentication SDK — registers a Fastify plugin, mounts login/logout/callback routes, manages encrypted session cookies, protects routes, and supports account linking.
+- [@auth0/auth0-fastify README — Examples](./packages/auth0-fastify/EXAMPLES.md): Advanced web patterns — account linking (connect/unconnect), custom routes, interactive login without mounted routes, backchannel logout, pushed authorization requests, and external session stores.
+- [@auth0/auth0-fastify-api README](./packages/auth0-fastify-api/README.md): API protection SDK — validates bearer access tokens (RS256, rejects HS*), enforces audience/scopes, and supports DPoP.
+- [@auth0/auth0-fastify-api README — Examples](./packages/auth0-fastify-api/EXAMPLES.md): Advanced API patterns — DPoP modes, On-Behalf-Of token exchange, and multi-domain configuration.
+
+## Getting started
+
+- [Monorepo README](./README.md): Overview, package list, and how to install/build the workspace (`npm install`, `npm run build`) and run the examples.
+- [Fastify web app example](./examples/example-fastify-web/README.md): Runnable server-rendered web app using `@auth0/auth0-fastify`.
+- [Fastify API example](./examples/example-fastify-api/README.md): Runnable protected API using `@auth0/auth0-fastify-api`.
+
+## Development
+
+- [CLAUDE.md](./CLAUDE.md): Repository guide for coding agents — layout, build/test/lint commands, and conventions.
+- [AGENTS.md](./AGENTS.md): Agent onboarding — how to choose the right package and integrate it.
+
+## Optional
+
+- [auth0-fastify CHANGELOG](./packages/auth0-fastify/CHANGELOG.md): Release history for the web package.
+- [auth0-fastify-api CHANGELOG](./packages/auth0-fastify-api/CHANGELOG.md): Release history for the API package.
+- [Auth0 Fastify web quickstart](https://auth0.com/docs/quickstart/webapp/fastify): Official guided quickstart for the web SDK.
+- [Auth0 Fastify backend quickstart](https://auth0.com/docs/quickstart/backend/fastify): Official guided quickstart for the API SDK.


### PR DESCRIPTION
## Summary

Adds three agent-discovery files at the repo root so AI coding agents (and humans) can quickly understand and integrate the SDKs:

- **AGENTS.md** — integration onboarding: how to choose between `@auth0/auth0-fastify` (web) and `@auth0/auth0-fastify-api` (API), minimal config for each, and security guardrails (env-var secrets, `fastify.trustProxy` for `x-forwarded-*`, don't weaken RS256/encrypted sessions).
- **llms.txt** — structured index (per the llms.txt convention) linking the package READMEs, EXAMPLES.md, CHANGELOGs, example apps, and the official Auth0 Fastify quickstarts.
- **CLAUDE.md** — repository dev guide: monorepo layout, npm-workspaces + Turborepo build/test/lint commands, Node 20+/Fastify v5+ requirements, and conventions.

All content is grounded in the actual repo (real config field names, package layout, version requirements). All internal links and both quickstart URLs were verified to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)