### PR TITLE
feat(auth0-fastify): add Custom Token Exchange support

### DIFF
--- a/packages/auth0-fastify/src/index.spec.ts
+++ b/packages/auth0-fastify/src/index.spec.ts
@@ -1118,3 +1118,263 @@ test('auth/unconnect/callback uses custom route when provided', async () => {
   expect(url.pathname).toBe('/');
   expect(url.searchParams.size).toBe(0);
 });
+
+test('loginWithCustomTokenExchange persists session and returns user as authenticated', async () => {
+  const fastify = Fastify();
+  fastify.register(plugin, {
+    domain: domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    appBaseUrl: 'http://localhost:3000',
+    sessionSecret: '<secret>',
+  });
+
+  fastify.post('/test/login-cte', async (request, reply) => {
+    await fastify.auth0Client!.loginWithCustomTokenExchange(
+      {
+        subjectToken: 'external-token',
+        subjectTokenType: 'urn:acme:legacy-token',
+      },
+      { request, reply }
+    );
+    return reply.send({ ok: true });
+  });
+
+  fastify.get('/test/session', async (request, reply) => {
+    const session = await fastify.auth0Client!.getSession({ request, reply });
+    return reply.send({ isAuthenticated: !!session?.user });
+  });
+
+  await fastify.ready();
+
+  // Step 1: perform CTE — session cookie is set on the response
+  const loginRes = await fastify.inject({ method: 'POST', url: '/test/login-cte' });
+  expect(loginRes.statusCode).toBe(200);
+
+  // Step 2: use the session cookie on a subsequent request
+  const sessionCookie = loginRes.headers['set-cookie']?.toString() ?? '';
+  const sessionRes = await fastify.inject({
+    method: 'GET',
+    url: '/test/session',
+    headers: { cookie: sessionCookie },
+  });
+
+  expect(sessionRes.statusCode).toBe(200);
+  expect(sessionRes.json().isAuthenticated).toBe(true);
+});
+
+test('loginWithCustomTokenExchange stores tokens in session so getAccessToken works', async () => {
+  const fastify = Fastify();
+  fastify.register(plugin, {
+    domain: domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    appBaseUrl: 'http://localhost:3000',
+    sessionSecret: '<secret>',
+  });
+
+  fastify.post('/test/login-cte-token', async (request, reply) => {
+    await fastify.auth0Client!.loginWithCustomTokenExchange(
+      {
+        subjectToken: 'external-token',
+        subjectTokenType: 'urn:acme:legacy-token',
+      },
+      { request, reply }
+    );
+    return reply.send({ ok: true });
+  });
+
+  fastify.get('/test/access-token', async (request, reply) => {
+    const tokenSet = await fastify.auth0Client!.getAccessToken({ request, reply });
+    return reply.send({ accessToken: tokenSet.accessToken });
+  });
+
+  await fastify.ready();
+
+  // Step 1: perform CTE — session cookie is set on the response
+  const loginRes = await fastify.inject({ method: 'POST', url: '/test/login-cte-token' });
+  expect(loginRes.statusCode).toBe(200);
+
+  // Step 2: use the session cookie to retrieve the access token
+  const sessionCookie = loginRes.headers['set-cookie']?.toString() ?? '';
+  const tokenRes = await fastify.inject({
+    method: 'GET',
+    url: '/test/access-token',
+    headers: { cookie: sessionCookie },
+  });
+
+  expect(tokenRes.statusCode).toBe(200);
+  expect(tokenRes.json().accessToken).toBe(accessToken);
+});
+
+test('loginWithCustomTokenExchange passes actor token when provided', async () => {
+  let capturedBody: Record<string, string> = {};
+  server.use(
+    http.post(mockOpenIdConfiguration.token_endpoint, async ({ request }) => {
+      capturedBody = Object.fromEntries(new URLSearchParams(await request.text()));
+      return HttpResponse.json({
+        access_token: accessToken,
+        id_token: await generateToken(domain, 'user_123', '<client_id>'),
+        expires_in: 60,
+        token_type: 'Bearer',
+      });
+    })
+  );
+
+  const fastify = Fastify();
+  fastify.register(plugin, {
+    domain: domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    appBaseUrl: 'http://localhost:3000',
+    sessionSecret: '<secret>',
+  });
+
+  fastify.post('/test/login-cte-actor', async (request, reply) => {
+    await fastify.auth0Client!.loginWithCustomTokenExchange(
+      {
+        subjectToken: 'external-token',
+        subjectTokenType: 'urn:acme:legacy-token',
+        actorToken: 'actor-token',
+        actorTokenType: 'urn:acme:actor-token',
+      },
+      { request, reply }
+    );
+    return reply.send({ ok: true });
+  });
+
+  await fastify.ready();
+
+  const res = await fastify.inject({ method: 'POST', url: '/test/login-cte-actor' });
+
+  expect(res.statusCode).toBe(200);
+  expect(capturedBody['actor_token']).toBe('actor-token');
+  expect(capturedBody['actor_token_type']).toBe('urn:acme:actor-token');
+});
+
+test('customTokenExchange returns TokenResponse without altering session', async () => {
+  const fastify = Fastify();
+  fastify.register(plugin, {
+    domain: domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    appBaseUrl: 'http://localhost:3000',
+    sessionSecret: '<secret>',
+  });
+
+  fastify.post('/test/cte', async (request, reply) => {
+    const tokenResponse = await fastify.auth0Client!.customTokenExchange(
+      {
+        subjectToken: 'external-token',
+        subjectTokenType: 'urn:acme:legacy-token',
+      },
+      { request, reply }
+    );
+    const session = await fastify.auth0Client!.getSession({ request, reply });
+    return reply.send({
+      accessToken: tokenResponse.accessToken,
+      sessionExists: !!session,
+    });
+  });
+
+  await fastify.ready();
+
+  const res = await fastify.inject({
+    method: 'POST',
+    url: '/test/cte',
+  });
+
+  expect(res.statusCode).toBe(200);
+  expect(res.json().accessToken).toBe(accessToken);
+  expect(res.json().sessionExists).toBe(false);
+});
+
+test('customTokenExchange passes actor token when provided', async () => {
+  let capturedBody: Record<string, string> = {};
+  server.use(
+    http.post(mockOpenIdConfiguration.token_endpoint, async ({ request }) => {
+      capturedBody = Object.fromEntries(new URLSearchParams(await request.text()));
+      return HttpResponse.json({
+        access_token: accessToken,
+        expires_in: 60,
+        token_type: 'Bearer',
+      });
+    })
+  );
+
+  const fastify = Fastify();
+  fastify.register(plugin, {
+    domain: domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    appBaseUrl: 'http://localhost:3000',
+    sessionSecret: '<secret>',
+  });
+
+  fastify.post('/test/cte-actor', async (request, reply) => {
+    await fastify.auth0Client!.customTokenExchange(
+      {
+        subjectToken: 'external-token',
+        subjectTokenType: 'urn:acme:legacy-token',
+        actorToken: 'actor-token',
+        actorTokenType: 'urn:acme:actor-token',
+      },
+      { request, reply }
+    );
+    return reply.send({ ok: true });
+  });
+
+  await fastify.ready();
+
+  const res = await fastify.inject({ method: 'POST', url: '/test/cte-actor' });
+
+  expect(res.statusCode).toBe(200);
+  expect(capturedBody['actor_token']).toBe('actor-token');
+  expect(capturedBody['actor_token_type']).toBe('urn:acme:actor-token');
+});
+
+test('customTokenExchange does not overwrite an existing session', async () => {
+  const fastify = Fastify();
+  fastify.register(plugin, {
+    domain: domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    appBaseUrl: 'http://localhost:3000',
+    sessionSecret: '<secret>',
+  });
+
+  const existingStateData: StateData = {
+    user: { sub: 'existing-user' },
+    idToken: '<existing_id_token>',
+    accessToken: '<existing_access_token>',
+    refreshToken: '<existing_refresh_token>',
+    tokenSets: [],
+    internal: { sid: '<sid>', createdAt: 1234567890 },
+  };
+  const sessionCookieValue = await encrypt(existingStateData, '<secret>', '__a0_session', Date.now() + 10000);
+
+  fastify.post('/test/cte-no-overwrite', async (request, reply) => {
+    await fastify.auth0Client!.customTokenExchange(
+      {
+        subjectToken: 'external-token',
+        subjectTokenType: 'urn:acme:legacy-token',
+      },
+      { request, reply }
+    );
+    const session = await fastify.auth0Client!.getSession({ request, reply });
+    return reply.send({ userSub: session?.user?.sub });
+  });
+
+  await fastify.ready();
+
+  const res = await fastify.inject({
+    method: 'POST',
+    url: '/test/cte-no-overwrite',
+    headers: {
+      cookie: `__a0_session.0=${sessionCookieValue}`,
+    },
+  });
+
+  expect(res.statusCode).toBe(200);
+  expect(res.json().userSub).toBe('existing-user');
+});

--- a/packages/auth0-fastify/src/index.ts
+++ b/packages/auth0-fastify/src/index.ts
@@ -15,7 +15,7 @@ import { createRouteUrl, toSafeRedirect } from './utils.js';
 import { FastifyCookieHandler } from './store/fastify-cookie-handler.js';
 
 export * from './types.js';
-export type { DomainResolver } from '@auth0/auth0-server-js';
+export type { DomainResolver, LoginWithCustomTokenExchangeOptions, LoginWithCustomTokenExchangeResult, CustomTokenExchangeOptions } from '@auth0/auth0-server-js';
 export { CookieTransactionStore } from '@auth0/auth0-server-js';
 
 declare module 'fastify' {


### PR DESCRIPTION
### Description

Expose `loginWithCustomTokenExchange` and `customTokenExchange` on auth0Client via the upgraded auth0-server-js ServerClient. Re-export the associated option and result types so consumers have full type coverage without importing from the underlying package directly.

### Testing

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom token exchange option and result types now exported for public use.

* **Tests**
  * Added comprehensive test coverage for custom token exchange functionality, including session management, token retrieval, and actor token field handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->