### PR TITLE
feat(auth0-fastify): add Custom Token Exchange support

### DIFF
--- a/packages/auth0-fastify/EXAMPLES.md
+++ b/packages/auth0-fastify/EXAMPLES.md
@@ -10,6 +10,7 @@
 - [Login using Custom Token Exchange](#login-using-custom-token-exchange)
   - [Performing a delegation exchange without a session](#performing-a-delegation-exchange-without-a-session)
   - [Using actor tokens for delegation](#using-actor-tokens-for-delegation)
+  - [Authenticating within an organization](#authenticating-within-an-organization)
 - [Multiple Custom Domains (MCD)](#multiple-custom-domains-mcd)
 
 ## Configuration
@@ -209,11 +210,10 @@ fastify.post('/custom-token-exchange', async (request, reply) => {
 
 After the exchange, the tokens are written to the session cookie, so the user is logged in. You can then use `getUser()`, `getSession()`, and `getAccessToken()` the same way as after any other login.
 
+Because `loginWithCustomTokenExchange()` writes the session cookie, pass the store options (`{ request, reply }`) so the SDK can read and write it, just like the other session methods in this plugin.
+
 > [!NOTE]
 > The `openid` scope is needed for `loginWithCustomTokenExchange()` to receive an ID token and fill in the session user. If you leave `openid` out, the SDK adds it for you. If you pass no `scope` at all, the SDK uses `openid profile email offline_access`.
-
-> [!IMPORTANT]
-> The store options (`{ request, reply }`) must be passed so the SDK can read and write the session cookie, just like the other client methods in this plugin.
 
 ### Performing a delegation exchange without a session
 
@@ -221,37 +221,31 @@ Use `customTokenExchange()` when you need a token to call another API but you do
 
 ```ts
 fastify.post('/delegate', async (request, reply) => {
-  const tokenResponse = await fastify.auth0Client!.customTokenExchange(
-    {
-      subjectToken: '<INCOMING_ACCESS_TOKEN>',
-      subjectTokenType: 'urn:ietf:params:oauth:token-type:access_token',
-      audience: '<DOWNSTREAM_API_AUDIENCE>',
-    },
-    { request, reply }
-  );
+  const tokenResponse = await fastify.auth0Client!.customTokenExchange({
+    subjectToken: '<INCOMING_ACCESS_TOKEN>',
+    subjectTokenType: 'urn:ietf:params:oauth:token-type:access_token',
+    audience: '<DOWNSTREAM_API_AUDIENCE>',
+  });
 
   // Use tokenResponse.accessToken to call the downstream API.
   return reply.send({ accessToken: tokenResponse.accessToken });
 });
 ```
 
-No session is read or written. The store options are only used for domain resolution when the plugin runs in resolver mode.
+No session is read or written. You can omit the store options (`{ request, reply }`) unless you run the plugin in [MCD resolver mode](#resolver-mode), where they are used only to resolve the domain.
 
 ### Using actor tokens for delegation
 
 When an intermediate service acts on behalf of a user, pass `actorToken` and `actorTokenType` together. Both are needed when you use actor tokens:
 
 ```ts
-const tokenResponse = await fastify.auth0Client!.customTokenExchange(
-  {
-    subjectToken: '<USER_TOKEN>',
-    subjectTokenType: 'urn:acme:user-token',
-    actorToken: '<SERVICE_TOKEN>',
-    actorTokenType: 'urn:acme:service-token',
-    audience: '<AUTH0_AUDIENCE>',
-  },
-  { request, reply }
-);
+const tokenResponse = await fastify.auth0Client!.customTokenExchange({
+  subjectToken: '<USER_TOKEN>',
+  subjectTokenType: 'urn:acme:user-token',
+  actorToken: '<SERVICE_TOKEN>',
+  actorTokenType: 'urn:acme:service-token',
+  audience: '<AUTH0_AUDIENCE>',
+});
 
 // tokenResponse.act holds the actor claim from the issued token, e.g. { sub: 'service-account-id' }.
 console.log(tokenResponse.act?.sub);
@@ -259,6 +253,25 @@ console.log(tokenResponse.act?.sub);
 
 > [!IMPORTANT]
 > When an actor token is sent, Auth0 does not return a refresh token, even if `offline_access` is in the scope. This is true for both methods. For `loginWithCustomTokenExchange()`, it means `getAccessToken()` will throw once the access token expires, because it cannot refresh on its own. Run the exchange again to get a new token.
+
+### Authenticating within an organization
+
+To exchange a token within an [organization](https://auth0.com/docs/manage-users/organizations) context, pass the `organization` option with the organization ID or name. The user is authenticated within that organization, and the organization ID is included in the access token. This works with both methods:
+
+```ts
+fastify.post('/custom-token-exchange', async (request, reply) => {
+  await fastify.auth0Client!.loginWithCustomTokenExchange(
+    {
+      subjectToken: '<EXTERNAL_TOKEN>',
+      subjectTokenType: 'urn:acme:legacy-token',
+      organization: '<ORGANIZATION_ID_OR_NAME>',
+    },
+    { request, reply }
+  );
+
+  return reply.send({ ok: true });
+});
+```
 
 ## Multiple Custom Domains (MCD)
 

--- a/packages/auth0-fastify/EXAMPLES.md
+++ b/packages/auth0-fastify/EXAMPLES.md
@@ -7,6 +7,9 @@
 - [The `ServerClient` instance](#the-serverclient-instance)
 - [Protecting Routes](#protecting-routes)
 - [Requesting an Access Token to call an API](#requesting-an-access-token-to-call-an-api)
+- [Login using Custom Token Exchange](#login-using-custom-token-exchange)
+  - [Performing a delegation exchange without a session](#performing-a-delegation-exchange-without-a-session)
+  - [Using actor tokens for delegation](#using-actor-tokens-for-delegation)
 - [Multiple Custom Domains (MCD)](#multiple-custom-domains-mcd)
 
 ## Configuration
@@ -179,6 +182,83 @@ Retrieving the token can be achieved by using `getAccessToken`:
 const accessTokenResult = await fastify.auth0Client.getAccessToken({ request, reply });
 console.log(accessTokenResult.accessToken);
 ```
+
+## Login using Custom Token Exchange
+
+Custom Token Exchange lets you create an Auth0 session from a token you already hold (for example a Google ID token or a token from a legacy system), without sending the user through a browser login. This needs a [Token Exchange Profile](https://auth0.com/docs/authenticate/custom-token-exchange) set up in your Auth0 tenant.
+
+The plugin does not mount a route for this flow. You call it yourself from your own route using `fastify.auth0Client`, in the same way you would use `loginBackchannel()`.
+
+Use `loginWithCustomTokenExchange()` when you want to exchange the token and store the result as a user session:
+
+```ts
+fastify.post('/custom-token-exchange', async (request, reply) => {
+  await fastify.auth0Client!.loginWithCustomTokenExchange(
+    {
+      subjectToken: '<EXTERNAL_TOKEN>',
+      subjectTokenType: 'urn:acme:legacy-token',
+      audience: '<AUTH0_AUDIENCE>',
+      scope: 'openid profile email',
+    },
+    { request, reply }
+  );
+
+  return reply.send({ ok: true });
+});
+```
+
+After the exchange, the tokens are written to the session cookie, so the user is logged in. You can then use `getUser()`, `getSession()`, and `getAccessToken()` the same way as after any other login.
+
+> [!NOTE]
+> The `openid` scope is needed for `loginWithCustomTokenExchange()` to receive an ID token and fill in the session user. If you leave `openid` out, the SDK adds it for you. If you pass no `scope` at all, the SDK uses `openid profile email offline_access`.
+
+> [!IMPORTANT]
+> The store options (`{ request, reply }`) must be passed so the SDK can read and write the session cookie, just like the other client methods in this plugin.
+
+### Performing a delegation exchange without a session
+
+Use `customTokenExchange()` when you need a token to call another API but you do not want to create or change the user session. This fits delegation and impersonation flows:
+
+```ts
+fastify.post('/delegate', async (request, reply) => {
+  const tokenResponse = await fastify.auth0Client!.customTokenExchange(
+    {
+      subjectToken: '<INCOMING_ACCESS_TOKEN>',
+      subjectTokenType: 'urn:ietf:params:oauth:token-type:access_token',
+      audience: '<DOWNSTREAM_API_AUDIENCE>',
+    },
+    { request, reply }
+  );
+
+  // Use tokenResponse.accessToken to call the downstream API.
+  return reply.send({ accessToken: tokenResponse.accessToken });
+});
+```
+
+No session is read or written. The store options are only used for domain resolution when the plugin runs in resolver mode.
+
+### Using actor tokens for delegation
+
+When an intermediate service acts on behalf of a user, pass `actorToken` and `actorTokenType` together. Both are needed when you use actor tokens:
+
+```ts
+const tokenResponse = await fastify.auth0Client!.customTokenExchange(
+  {
+    subjectToken: '<USER_TOKEN>',
+    subjectTokenType: 'urn:acme:user-token',
+    actorToken: '<SERVICE_TOKEN>',
+    actorTokenType: 'urn:acme:service-token',
+    audience: '<AUTH0_AUDIENCE>',
+  },
+  { request, reply }
+);
+
+// tokenResponse.act holds the actor claim from the issued token, e.g. { sub: 'service-account-id' }.
+console.log(tokenResponse.act?.sub);
+```
+
+> [!IMPORTANT]
+> When an actor token is sent, Auth0 does not return a refresh token, even if `offline_access` is in the scope. This is true for both methods. For `loginWithCustomTokenExchange()`, it means `getAccessToken()` will throw once the access token expires, because it cannot refresh on its own. Run the exchange again to get a new token.
 
 ## Multiple Custom Domains (MCD)
 

--- a/packages/auth0-fastify/package.json
+++ b/packages/auth0-fastify/package.json
@@ -34,7 +34,7 @@
     "vitest": "^3.0.5"
   },
   "dependencies": {
-    "@auth0/auth0-server-js": "^1.6.0",
+    "@auth0/auth0-server-js": "^1.6.1",
     "@fastify/cookie": "^11.0.2",
     "fastify": "^5.3.2",
     "fastify-plugin": "^5.0.1"

--- a/packages/auth0-fastify/package.json
+++ b/packages/auth0-fastify/package.json
@@ -34,7 +34,7 @@
     "vitest": "^3.0.5"
   },
   "dependencies": {
-    "@auth0/auth0-server-js": "^1.4.0",
+    "@auth0/auth0-server-js": "^1.6.0",
     "@fastify/cookie": "^11.0.2",
     "fastify": "^5.3.2",
     "fastify-plugin": "^5.0.1"

--- a/packages/auth0-fastify/src/index.spec.ts
+++ b/packages/auth0-fastify/src/index.spec.ts
@@ -1198,6 +1198,59 @@ test('loginWithCustomTokenExchange stores a token under the configured audience'
   expect(session.tokenSets[0]?.accessToken).toBe(accessToken);
 });
 
+test('loginWithCustomTokenExchange persists the act claim on the session user', async () => {
+  server.use(
+    http.post(mockOpenIdConfiguration.token_endpoint, async () => {
+      return HttpResponse.json({
+        access_token: accessToken,
+        id_token: await generateToken(domain, 'user_123', '<client_id>', undefined, undefined, undefined, {
+          act: { sub: 'service-account-id' },
+        }),
+        expires_in: 60,
+        token_type: 'Bearer',
+      });
+    })
+  );
+
+  const fastify = Fastify();
+  fastify.register(plugin, {
+    domain: domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    appBaseUrl: 'http://localhost:3000',
+    sessionSecret: '<secret>',
+  });
+
+  fastify.post('/custom-token-exchange', async (request, reply) => {
+    await fastify.auth0Client!.loginWithCustomTokenExchange(
+      {
+        subjectToken: 'user-token',
+        subjectTokenType: 'urn:acme:user-token',
+        actorToken: 'service-token',
+        actorTokenType: 'urn:acme:service-token',
+      },
+      { request, reply }
+    );
+
+    return reply.send({ ok: true });
+  });
+
+  const res = await fastify.inject({
+    method: 'POST',
+    url: '/custom-token-exchange',
+  });
+
+  expect(res.statusCode).toBe(200);
+
+  const cookieName = '__a0_session';
+  const cookieValueRaw = fastify.parseCookie(res.headers['set-cookie']?.toString() as string)[
+    `${cookieName}.0`
+  ] as string;
+  const session = (await decrypt(cookieValueRaw, '<secret>', cookieName)) as StateData;
+
+  expect((session.user?.act as { sub: string })?.sub).toBe('service-account-id');
+});
+
 test('customTokenExchange returns a token without creating a session', async () => {
   const fastify = Fastify();
   fastify.register(plugin, {
@@ -1217,7 +1270,8 @@ test('customTokenExchange returns a token without creating a session', async () 
       { request, reply }
     );
 
-    return reply.send({ accessToken: tokenResponse.accessToken });
+    const session = await fastify.auth0Client!.getSession({ request, reply });
+    return reply.send({ accessToken: tokenResponse.accessToken, hasSession: !!session });
   });
 
   const res = await fastify.inject({
@@ -1227,6 +1281,57 @@ test('customTokenExchange returns a token without creating a session', async () 
 
   expect(res.statusCode).toBe(200);
   expect(res.json().accessToken).toBe(accessToken);
+  expect(res.json().hasSession).toBe(false);
+  expect(res.headers['set-cookie']).toBeUndefined();
+});
+
+test('customTokenExchange does not overwrite an existing session', async () => {
+  const fastify = Fastify();
+  fastify.register(plugin, {
+    domain: domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    appBaseUrl: 'http://localhost:3000',
+    sessionSecret: '<secret>',
+  });
+
+  const stateData: StateData = {
+    user: {
+      sub: 'original-user',
+    },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [],
+    internal: {
+      sid: '<sid>',
+      createdAt: 1234567890,
+    },
+  };
+  const cookieValue = await encrypt(stateData, '<secret>', '__a0_session', Date.now() + 1000);
+
+  fastify.post('/delegate', async (request, reply) => {
+    await fastify.auth0Client!.customTokenExchange(
+      {
+        subjectToken: 'external-token-123',
+        subjectTokenType: 'urn:acme:legacy-token',
+      },
+      { request, reply }
+    );
+
+    const session = await fastify.auth0Client!.getSession({ request, reply });
+    return reply.send({ sub: session?.user?.sub });
+  });
+
+  const res = await fastify.inject({
+    method: 'POST',
+    url: '/delegate',
+    headers: {
+      cookie: `__a0_session.0=${cookieValue}`,
+    },
+  });
+
+  expect(res.statusCode).toBe(200);
+  expect(res.json().sub).toBe('original-user');
   expect(res.headers['set-cookie']).toBeUndefined();
 });
 
@@ -1234,9 +1339,7 @@ test('customTokenExchange surfaces the act claim when an actor token is used', a
   server.use(
     http.post(mockOpenIdConfiguration.token_endpoint, async () => {
       return HttpResponse.json({
-        access_token: await generateToken(domain, 'user_123', '<client_id>', undefined, undefined, undefined, {
-          act: { sub: 'service-account-id' },
-        }),
+        access_token: accessToken,
         id_token: await generateToken(domain, 'user_123', '<client_id>', undefined, undefined, undefined, {
           act: { sub: 'service-account-id' },
         }),
@@ -1305,6 +1408,8 @@ test('customTokenExchange throws when the exchange fails', async () => {
       );
       return reply.send({ ok: true });
     } catch (e) {
+      // auth0-server-js exposes TokenExchangeError as a type only, not a runtime
+      // value, so we match on the error name rather than `instanceof`.
       return reply.code(400).send({ name: (e as Error).name });
     }
   });
@@ -1316,4 +1421,47 @@ test('customTokenExchange throws when the exchange fails', async () => {
 
   expect(res.statusCode).toBe(400);
   expect(res.json().name).toBe('TokenExchangeError');
+});
+
+test('customTokenExchange forwards the organization to the token endpoint', async () => {
+  let capturedOrganization: string | null = null;
+  server.use(
+    http.post(mockOpenIdConfiguration.token_endpoint, async ({ request }) => {
+      const info = await request.formData();
+      capturedOrganization = info.get('organization') as string;
+      return HttpResponse.json({
+        access_token: accessToken,
+        id_token: await generateToken(domain, 'user_123', '<client_id>'),
+        expires_in: 60,
+        token_type: 'Bearer',
+      });
+    })
+  );
+
+  const fastify = Fastify();
+  fastify.register(plugin, {
+    domain: domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    appBaseUrl: 'http://localhost:3000',
+    sessionSecret: '<secret>',
+  });
+
+  fastify.post('/delegate', async (request, reply) => {
+    await fastify.auth0Client!.customTokenExchange({
+      subjectToken: 'external-token-123',
+      subjectTokenType: 'urn:acme:legacy-token',
+      organization: 'org_123',
+    });
+
+    return reply.send({ ok: true });
+  });
+
+  const res = await fastify.inject({
+    method: 'POST',
+    url: '/delegate',
+  });
+
+  expect(res.statusCode).toBe(200);
+  expect(capturedOrganization).toBe('org_123');
 });

--- a/packages/auth0-fastify/src/index.spec.ts
+++ b/packages/auth0-fastify/src/index.spec.ts
@@ -1118,3 +1118,202 @@ test('auth/unconnect/callback uses custom route when provided', async () => {
   expect(url.pathname).toBe('/');
   expect(url.searchParams.size).toBe(0);
 });
+
+test('loginWithCustomTokenExchange writes the exchanged user to the session', async () => {
+  const fastify = Fastify();
+  fastify.register(plugin, {
+    domain: domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    appBaseUrl: 'http://localhost:3000',
+    sessionSecret: '<secret>',
+  });
+
+  fastify.post('/custom-token-exchange', async (request, reply) => {
+    await fastify.auth0Client!.loginWithCustomTokenExchange(
+      {
+        subjectToken: 'external-token-123',
+        subjectTokenType: 'urn:acme:legacy-token',
+      },
+      { request, reply }
+    );
+
+    return reply.send({ ok: true });
+  });
+
+  const res = await fastify.inject({
+    method: 'POST',
+    url: '/custom-token-exchange',
+  });
+
+  expect(res.statusCode).toBe(200);
+
+  const cookieName = '__a0_session';
+  const cookieValueRaw = fastify.parseCookie(res.headers['set-cookie']?.toString() as string)[
+    `${cookieName}.0`
+  ] as string;
+  const session = (await decrypt(cookieValueRaw, '<secret>', cookieName)) as StateData;
+
+  expect(session.user?.sub).toBe('user_123');
+});
+
+test('loginWithCustomTokenExchange stores a token under the configured audience', async () => {
+  const fastify = Fastify();
+  fastify.register(plugin, {
+    domain: domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    audience: 'https://api.example.com',
+    appBaseUrl: 'http://localhost:3000',
+    sessionSecret: '<secret>',
+  });
+
+  fastify.post('/custom-token-exchange', async (request, reply) => {
+    await fastify.auth0Client!.loginWithCustomTokenExchange(
+      {
+        subjectToken: 'external-token-123',
+        subjectTokenType: 'urn:acme:legacy-token',
+        audience: 'https://api.example.com',
+      },
+      { request, reply }
+    );
+
+    return reply.send({ ok: true });
+  });
+
+  const res = await fastify.inject({
+    method: 'POST',
+    url: '/custom-token-exchange',
+  });
+
+  expect(res.statusCode).toBe(200);
+
+  const cookieName = '__a0_session';
+  const cookieValueRaw = fastify.parseCookie(res.headers['set-cookie']?.toString() as string)[
+    `${cookieName}.0`
+  ] as string;
+  const session = (await decrypt(cookieValueRaw, '<secret>', cookieName)) as StateData;
+
+  expect(session.tokenSets[0]?.audience).toBe('https://api.example.com');
+  expect(session.tokenSets[0]?.accessToken).toBe(accessToken);
+});
+
+test('customTokenExchange returns a token without creating a session', async () => {
+  const fastify = Fastify();
+  fastify.register(plugin, {
+    domain: domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    appBaseUrl: 'http://localhost:3000',
+    sessionSecret: '<secret>',
+  });
+
+  fastify.post('/delegate', async (request, reply) => {
+    const tokenResponse = await fastify.auth0Client!.customTokenExchange(
+      {
+        subjectToken: 'external-token-123',
+        subjectTokenType: 'urn:acme:legacy-token',
+      },
+      { request, reply }
+    );
+
+    return reply.send({ accessToken: tokenResponse.accessToken });
+  });
+
+  const res = await fastify.inject({
+    method: 'POST',
+    url: '/delegate',
+  });
+
+  expect(res.statusCode).toBe(200);
+  expect(res.json().accessToken).toBe(accessToken);
+  expect(res.headers['set-cookie']).toBeUndefined();
+});
+
+test('customTokenExchange surfaces the act claim when an actor token is used', async () => {
+  server.use(
+    http.post(mockOpenIdConfiguration.token_endpoint, async () => {
+      return HttpResponse.json({
+        access_token: await generateToken(domain, 'user_123', '<client_id>', undefined, undefined, undefined, {
+          act: { sub: 'service-account-id' },
+        }),
+        id_token: await generateToken(domain, 'user_123', '<client_id>', undefined, undefined, undefined, {
+          act: { sub: 'service-account-id' },
+        }),
+        expires_in: 60,
+        token_type: 'Bearer',
+      });
+    })
+  );
+
+  const fastify = Fastify();
+  fastify.register(plugin, {
+    domain: domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    appBaseUrl: 'http://localhost:3000',
+    sessionSecret: '<secret>',
+  });
+
+  fastify.post('/delegate', async (request, reply) => {
+    const tokenResponse = await fastify.auth0Client!.customTokenExchange(
+      {
+        subjectToken: 'user-token',
+        subjectTokenType: 'urn:acme:user-token',
+        actorToken: 'service-token',
+        actorTokenType: 'urn:acme:service-token',
+      },
+      { request, reply }
+    );
+
+    return reply.send({ act: tokenResponse.act });
+  });
+
+  const res = await fastify.inject({
+    method: 'POST',
+    url: '/delegate',
+  });
+
+  expect(res.statusCode).toBe(200);
+  expect(res.json().act).toEqual({ sub: 'service-account-id' });
+});
+
+test('customTokenExchange throws when the exchange fails', async () => {
+  server.use(
+    http.post(mockOpenIdConfiguration.token_endpoint, () => {
+      return HttpResponse.json({ error: 'invalid_request', error_description: 'bad token' }, { status: 400 });
+    })
+  );
+
+  const fastify = Fastify();
+  fastify.register(plugin, {
+    domain: domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    appBaseUrl: 'http://localhost:3000',
+    sessionSecret: '<secret>',
+  });
+
+  fastify.post('/delegate', async (request, reply) => {
+    try {
+      await fastify.auth0Client!.customTokenExchange(
+        {
+          subjectToken: 'external-token-123',
+          subjectTokenType: 'urn:acme:legacy-token',
+        },
+        { request, reply }
+      );
+      return reply.send({ ok: true });
+    } catch (e) {
+      return reply.code(400).send({ name: (e as Error).name });
+    }
+  });
+
+  const res = await fastify.inject({
+    method: 'POST',
+    url: '/delegate',
+  });
+
+  expect(res.statusCode).toBe(400);
+  expect(res.json().name).toBe('TokenExchangeError');
+});

--- a/packages/auth0-fastify/src/index.ts
+++ b/packages/auth0-fastify/src/index.ts
@@ -20,6 +20,8 @@ export type {
   LoginWithCustomTokenExchangeOptions,
   CustomTokenExchangeOptions,
   LoginWithCustomTokenExchangeResult,
+  TokenResponse,
+  ActClaim,
 } from '@auth0/auth0-server-js';
 export { CookieTransactionStore } from '@auth0/auth0-server-js';
 

--- a/packages/auth0-fastify/src/index.ts
+++ b/packages/auth0-fastify/src/index.ts
@@ -24,6 +24,7 @@ export type {
   ActClaim,
 } from '@auth0/auth0-server-js';
 export { CookieTransactionStore } from '@auth0/auth0-server-js';
+export { TokenExchangeError, MissingClientAuthError } from '@auth0/auth0-server-js';
 
 declare module 'fastify' {
   /**

--- a/packages/auth0-fastify/src/index.ts
+++ b/packages/auth0-fastify/src/index.ts
@@ -16,6 +16,11 @@ import { FastifyCookieHandler } from './store/fastify-cookie-handler.js';
 
 export * from './types.js';
 export type { DomainResolver } from '@auth0/auth0-server-js';
+export type {
+  LoginWithCustomTokenExchangeOptions,
+  CustomTokenExchangeOptions,
+  LoginWithCustomTokenExchangeResult,
+} from '@auth0/auth0-server-js';
 export { CookieTransactionStore } from '@auth0/auth0-server-js';
 
 declare module 'fastify' {


### PR DESCRIPTION
### Changes 
Adds Custom Token Exchange (CTE) support to the `Fastify` plugin, building on the `CTE` methods released in `@auth0/auth0-server-js v1.6.0`.

The plugin follows the same client-only pattern it already uses for `CIBA` (`loginBackchannel`): no new mounted route. Developers call the methods on `fastify.auth0Client` from their own routes.

- Re-exports `LoginWithCustomTokenExchangeOptions`, `CustomTokenExchangeOptions`, and `LoginWithCustomTokenExchangeResult` from auth0-server-js so consumers can import them from @auth0/auth0-fastify.
- Bumps `@auth0/auth0-server-js` from `^1.4.0` to `^1.6.0` (the version that ships the `CTE` methods).
- Adds an `EXAMPLES` section covering both methods, actor-token delegation and the `act` claim, the openid-scope note, and the refresh-token suppression caveat when an actor token is used.

No change to the plugin body. The methods are already reachable on the decorated client; this PR makes the types and docs first-class.

### Testing
Added unit tests in index.spec.ts:
  - `loginWithCustomTokenExchange` writes the exchanged user to the session
  - `loginWithCustomTokenExchange` stores the token under the configured audience
  - `customTokenExchange` returns a token without creating a session
  - `customTokenExchange` surfaces the act claim when an actor token is used
  - `customTokenExchange` throws when the exchange fails

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a “Login using Custom Token Exchange” guide, including delegation (with/without sessions), actor-token delegation, audience and organization examples, and clarified session and refresh-token behavior.

* **Tests**
  * Added coverage for session cookie updates, audience-specific token storage, actor claim persistence, correct behavior when sessions already exist, organization forwarding, and token-exchange error handling.

* **Chores**
  * Updated `@auth0/auth0-server-js` dependency to `^1.6.1`.

* **Refactor**
  * Re-exported additional custom token exchange TypeScript types and related error types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->