### PR TITLE
docs: add features to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,48 @@ Auth0-Fastify Mono Repo, containing SDKs for implementing user authentication in
 [![License](https://img.shields.io/:license-mit-blue.svg?style=flat)](https://opensource.org/licenses/MIT)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/auth0/auth0-fastify)
 
-📚 [Packages](#packages) - 💬 [Feedback](#feedback)
+📚 [Packages](#packages) - 🔎 [Features](#features) - 💬 [Feedback](#feedback)
 
 ## Packages
 
-- [`auth0-fastify`](./packages/auth0-fastify/README.md) - Authentication SDK for Fastify Applications on JavaScript runtimes.
-- [`auth0-fastify-api`](./packages/auth0-fastify-api/README.md) - Authentication SDK for Fastify API's on JavaScript runtimes.
+Two SDKs — pick the one that matches your application:
+
+- [`@auth0/auth0-fastify`](./packages/auth0-fastify/README.md) — for server-rendered **web apps** where users log in. Authenticates with an encrypted browser session cookie and handles login, logout, callback, and session management.
+- [`@auth0/auth0-fastify-api`](./packages/auth0-fastify-api/README.md) — for **APIs** / resource servers consumed by SPAs, mobile, or services. Authenticates with an `Authorization: Bearer <access_token>` and authorizes by scopes and claims.
+
+## Features
+
+Jump straight to the capability you need.
+
+### `@auth0/auth0-fastify` — Web applications
+
+| Feature | What it does |
+| --- | --- |
+| [Quick start](./packages/auth0-fastify/README.md#getting-started) | Register the Auth0 plugin with `fastify.register` in a few lines |
+| [Built-in routes](./packages/auth0-fastify/README.md#routes) | `/auth/login`, `/auth/logout`, `/auth/callback`, back-channel logout |
+| [Custom login / logout / callback](./packages/auth0-fastify/README.md#3-adding-login-and-logout) | Roll your own routes instead of the mounted ones |
+| [Configure mounted routes](./packages/auth0-fastify/EXAMPLES.md#configuring-the-mounted-routes) | Disable the built-in routes or add account-linking routes |
+| [Protect a route with a session](./packages/auth0-fastify/README.md#4-protecting-routes) | Gate server-rendered pages behind a login session |
+| [Get the current session / user](./packages/auth0-fastify/README.md#4-protecting-routes) | Read the authenticated user with `getUser()` / `getSession()` |
+| [Call an API (`getAccessToken`)](./packages/auth0-fastify/README.md#requesting-an-access-token-to-call-an-api) | Get an access token to call APIs as the user |
+| [Custom Token Exchange](./packages/auth0-fastify/EXAMPLES.md#login-using-custom-token-exchange) | Create a session from an external token without a browser login |
+| [Multiple Custom Domains (MCD)](./packages/auth0-fastify/EXAMPLES.md#multiple-custom-domains-mcd) | Resolve the Auth0 domain per request |
+| [Custom `fetch`](./packages/auth0-fastify/EXAMPLES.md#configuring-a-customfetch-implementation) | Swap in your own fetch (proxies, retries, instrumentation) |
+| [Discovery cache](./packages/auth0-fastify/EXAMPLES.md#discovery-cache) | Control caching of OIDC discovery metadata and JWKS |
+
+### `@auth0/auth0-fastify-api` — APIs
+
+| Feature | What it does |
+| --- | --- |
+| [Quick start](./packages/auth0-fastify-api/README.md#getting-started) | Protect an API with `fastify.register` in a few lines |
+| [Protect an API route (`requireAuth`)](./packages/auth0-fastify-api/README.md#protecting-api-routes) | Require a valid bearer access token in a preHandler |
+| [Read token claims (`request.user`)](./packages/auth0-fastify-api/README.md#protecting-api-routes) | Access claims extracted from the verified token |
+| [Custom token / user type](./packages/auth0-fastify-api/README.md#protecting-api-routes) | Type your custom claims via module augmentation |
+| [DPoP (proof-of-possession)](./packages/auth0-fastify-api/EXAMPLES.md#dpop-demonstration-of-proof-of-possession) | Bind access tokens to a client key pair (RFC 9449) |
+| [On-Behalf-Of Token Exchange](./packages/auth0-fastify-api/README.md#on-behalf-of-token-exchange) | Exchange the caller's token for a downstream API token |
+| [Multiple Custom Domains (MCD)](./packages/auth0-fastify-api/EXAMPLES.md#multiple-custom-domains-mcd) | Accept tokens from multiple issuer domains of one tenant |
+| [Custom `fetch`](./packages/auth0-fastify-api/EXAMPLES.md#configuring-a-customfetch-implementation) | Swap in your own fetch (proxies, retries, instrumentation) |
+| [Discovery cache](./packages/auth0-fastify-api/EXAMPLES.md#discovery-cache-configuration) | Control caching of discovery metadata and signing keys |
 
 ## Running Examples
 

--- a/packages/auth0-fastify-api/README.md
+++ b/packages/auth0-fastify-api/README.md
@@ -4,12 +4,28 @@ The Auth0 Fastify-API SDK is a library for protecting API's in Fastify applicati
 ![Downloads](https://img.shields.io/npm/dw/@auth0/auth0-fastify-api)
 [![License](https://img.shields.io/:license-mit-blue.svg?style=flat)](https://opensource.org/licenses/MIT)
 
-📚 [Documentation](#documentation) - 🚀 [Getting Started](#getting-started) - 💬 [Feedback](#feedback)
+📚 [Documentation](#documentation) - 🔎 [Features](#features) - 🚀 [Getting Started](#getting-started) - 💬 [Feedback](#feedback)
 
 ## Documentation
 
 - [Examples](https://github.com/auth0/auth0-fastify/blob/main/packages/auth0-fastify-api/EXAMPLES.md) - examples for your different use cases.
 - [Docs Site](https://auth0.com/docs) - explore our docs site and learn more about Auth0.
+
+## Features
+
+Jump straight to the capability you need.
+
+| Feature | What it does |
+| --- | --- |
+| [Quick start](#getting-started) | Protect an API with `fastify.register` in a few lines |
+| [Protect an API route (`requireAuth`)](#protecting-api-routes) | Require a valid bearer access token in a preHandler |
+| [Read token claims (`request.user`)](#protecting-api-routes) | Access claims extracted from the verified token |
+| [Custom token / user type](#protecting-api-routes) | Type your custom claims via module augmentation |
+| [DPoP (proof-of-possession)](./EXAMPLES.md#dpop-demonstration-of-proof-of-possession) | Bind access tokens to a client key pair (RFC 9449) |
+| [On-Behalf-Of Token Exchange](#on-behalf-of-token-exchange) | Exchange the caller's token for a downstream API token |
+| [Multiple Custom Domains (MCD)](./EXAMPLES.md#multiple-custom-domains-mcd) | Accept tokens from multiple issuer domains of one tenant |
+| [Custom `fetch`](./EXAMPLES.md#configuring-a-customfetch-implementation) | Swap in your own fetch (proxies, retries, instrumentation) |
+| [Discovery cache](./EXAMPLES.md#discovery-cache-configuration) | Control caching of discovery metadata and signing keys |
 
 ## Getting Started
 

--- a/packages/auth0-fastify/README.md
+++ b/packages/auth0-fastify/README.md
@@ -4,12 +4,30 @@ The Auth0 Fastify SDK is a library for implementing user authentication in Fasti
 ![Downloads](https://img.shields.io/npm/dw/@auth0/auth0-fastify)
 [![License](https://img.shields.io/:license-mit-blue.svg?style=flat)](https://opensource.org/licenses/MIT)
 
-📚 [Documentation](#documentation) - 🚀 [Getting Started](#getting-started) - 💬 [Feedback](#feedback)
+📚 [Documentation](#documentation) - 🔎 [Features](#features) - 🚀 [Getting Started](#getting-started) - 💬 [Feedback](#feedback)
 
 ## Documentation
 
 - [Examples](https://github.com/auth0/auth0-fastify/blob/main/packages/auth0-fastify/EXAMPLES.md) - examples for your different use cases.
 - [Docs Site](https://auth0.com/docs) - explore our docs site and learn more about Auth0.
+
+## Features
+
+Jump straight to the capability you need.
+
+| Feature | What it does |
+| --- | --- |
+| [Quick start](#getting-started) | Register the Auth0 plugin with `fastify.register` in a few lines |
+| [Built-in routes](#routes) | `/auth/login`, `/auth/logout`, `/auth/callback`, back-channel logout |
+| [Custom login / logout / callback](#3-adding-login-and-logout) | Roll your own routes instead of the mounted ones |
+| [Configure mounted routes](./EXAMPLES.md#configuring-the-mounted-routes) | Disable the built-in routes or add account-linking routes |
+| [Protect a route with a session](#4-protecting-routes) | Gate server-rendered pages behind a login session |
+| [Get the current session / user](#4-protecting-routes) | Read the authenticated user with `getUser()` / `getSession()` |
+| [Call an API (`getAccessToken`)](#requesting-an-access-token-to-call-an-api) | Get an access token to call APIs as the user |
+| [Custom Token Exchange](./EXAMPLES.md#login-using-custom-token-exchange) | Create a session from an external token without a browser login |
+| [Multiple Custom Domains (MCD)](./EXAMPLES.md#multiple-custom-domains-mcd) | Resolve the Auth0 domain per request |
+| [Custom `fetch`](./EXAMPLES.md#configuring-a-customfetch-implementation) | Swap in your own fetch (proxies, retries, instrumentation) |
+| [Discovery cache](./EXAMPLES.md#discovery-cache) | Control caching of OIDC discovery metadata and JWKS |
 
 ## Getting Started
 


### PR DESCRIPTION
## Description

Turns the READMEs into a discovery surface so developers — and AI agents — can find the right SDK and jump straight to the capability they need. Comparable to auth0/auth0-express#15.

### Root `README.md`
- Sharpened the package descriptions to clarify use cases (server-rendered **web apps** vs. **APIs**/resource servers) and the authentication mechanism each uses.
- Added a **Features** section with per-SDK tables linking to specific capabilities.

### Per-package READMEs (`auth0-fastify`, `auth0-fastify-api`)
- Added a **Features** section with a table mapping each capability to a description and a deep link into the package README or `EXAMPLES.md`.

The tables are tuned to what each Fastify SDK actually exposes (e.g. Custom Token Exchange and session protection for the web SDK; DPoP, On-Behalf-Of token exchange, and `requireAuth` for the API SDK).

## Notes
- Documentation only — no code or behavior changes.
- All anchor links were verified against the actual headings in the README and EXAMPLES files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured SDK selection guidance to clarify positioning for web apps versus APIs.
  * Expanded feature documentation with capability tables and in-page navigation.
  * Enhanced README organization for improved discoverability and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->