### PR TITLE
fix(example-fastify-web): bump @fastify/static to ^9.1.1

### DIFF
--- a/examples/example-fastify-web/package.json
+++ b/examples/example-fastify-web/package.json
@@ -15,7 +15,7 @@
     },
     "dependencies": {
         "@auth0/auth0-fastify": "*",
-        "@fastify/static": "^8.1.1",
+        "@fastify/static": "^9.1.1",
         "@fastify/view": "^10.0.2",
         "dotenv": "^16.4.7",
         "ejs": "^3.1.10",


### PR DESCRIPTION
## Scope: example app only

This fixes a vulnerable dependency in the **`examples/example-fastify-web`** example application. It does **not** touch either published SDK — neither `@auth0/auth0-fastify` nor `@auth0/auth0-fastify-api` depends on `@fastify/static`, so **no package release is required**.

## What & why

The web example pinned `@fastify/static` at `^8.1.1`, which is affected by two advisories (published April 2026):

- **GHSA-pr96-94w5-mx2h** — Path Traversal in Directory Listing (Moderate)
- **GHSA-x428-ghpx-8j92** — Route Guard Bypass via Encoded Path Separators (Moderate)

Both affect `>= 8.0.0, <= 9.1.0`, and there is **no patched 8.x release** — the only fix is `9.1.1`+. This PR bumps the example to `^9.1.1` (resolves to `9.1.3`).

## Compatibility

`@fastify/static` v9 remains compatible with Fastify v5 (`fastify-plugin ^5`). The example only uses the basic `register(fastifyStatic, { root })` form, which is unaffected by the v8 → v9 major.

## Verification

- `npm install` resolves cleanly; `npm audit` no longer flags `@fastify/static`.
- `npm run build -w example-fastify-web` compiles successfully.