### PR TITLE
feat(auth0-fastify): bump @auth0/auth0-server-js to ^1.9.0

### DIFF
--- a/packages/auth0-fastify/package.json
+++ b/packages/auth0-fastify/package.json
@@ -34,7 +34,7 @@
     "vitest": "^3.0.5"
   },
   "dependencies": {
-    "@auth0/auth0-server-js": "^1.6.1",
+    "@auth0/auth0-server-js": "^1.9.0",
     "@fastify/cookie": "^11.0.2",
     "fastify": "^5.3.2",
     "fastify-plugin": "^5.0.1"

--- a/packages/auth0-fastify/src/index.spec.ts
+++ b/packages/auth0-fastify/src/index.spec.ts
@@ -1431,7 +1431,9 @@ test('customTokenExchange forwards the organization to the token endpoint', asyn
       capturedOrganization = info.get('organization') as string;
       return HttpResponse.json({
         access_token: accessToken,
-        id_token: await generateToken(domain, 'user_123', '<client_id>'),
+        id_token: await generateToken(domain, 'user_123', '<client_id>', undefined, undefined, undefined, {
+          org_id: 'org_123',
+        }),
         expires_in: 60,
         token_type: 'Bearer',
       });


### PR DESCRIPTION
Bumps `@auth0/auth0-server-js` from `^1.6.1` to `^1.9.0` in `@auth0/auth0-fastify`.

## Behavior change to be aware of:
The bump transitively pulls in `@auth0/auth0-auth-js` 1.11, which adds **organization-claim validation** to token exchange. When `organization` is passed to `customTokenExchange` (or supplied through the interactive login flow), the returned ID token's `org_id` / `org_name` claim is now validated against the requested organization and throws `OrganizationValidationError` on a mismatch or when the claim is absent.

This is intended security hardening, but consumers already passing `organization` should be aware. The `customTokenExchange forwards the organization to the token endpoint` spec was updated so its mock ID token carries a matching `org_id` claim.

## Out of scope (follow-up)
Surfacing the new server-js features (passkey/passwordless, IPSIE `session_expiry`,  and first-class `organization` / `invitation` options) through the Fastify plugin's options and routes is intentionally **deferred to a separate PR**. This PR is the dependency bump only.

The `auth0-fastify` package version is intentionally left unchanged; the release PR owns the version bump and CHANGELOG entry.

## Testing
  - [x] `npm run build` — both packages + example app compile, including type declarations
  - [x] `npm run lint` — clean across both packages
  - [x] `npm run test` — auth0-fastify **41/41**, auth0-fastify-api **59/59**
  - [x] Verified the new org-claim validation is genuinely exercised (mismatched `org_id` fails the spec as expected)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated coverage for organization-aware token exchange behavior.
* **Chores**
  * Refreshed an authentication dependency to a newer release, helping keep the integration up to date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->