### PR TITLE
ci: add build workflow for examples

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -4,9 +4,9 @@ on:
   merge_group:
   workflow_dispatch:
   pull_request:
-    branches: [main, early-access]
+    branches: [main]
   push:
-    branches: [main, early-access]
+    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,0 +1,73 @@
+name: Build and Test Examples
+
+on:
+  merge_group:
+  workflow_dispatch:
+  pull_request:
+    branches: [main, early-access]
+  push:
+    branches: [main, early-access]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  example-fastify-web:
+    name: Web App
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Setup Node.js with npm caching
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          package-manager-cache: false
+
+      - name: Update npm
+        run: npm install -g npm@11.10.0
+
+      - name: Install dependencies
+        run: npm install
+
+      # The example imports @auth0/auth0-fastify from its built dist, so the
+      # SDK must be built before the example can build.
+      - name: Build auth0-fastify
+        run: npm run build -w @auth0/auth0-fastify
+
+      - name: Build example-fastify-web
+        run: npm run build -w example-fastify-web
+
+  example-fastify-api:
+    name: API
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Setup Node.js with npm caching
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          package-manager-cache: false
+
+      - name: Update npm
+        run: npm install -g npm@11.10.0
+
+      - name: Install dependencies
+        run: npm install
+
+      # The example imports @auth0/auth0-fastify-api from its built dist, so the
+      # SDK must be built before the example can build.
+      - name: Build auth0-fastify-api
+        run: npm run build -w @auth0/auth0-fastify-api
+
+      - name: Build example-fastify-api
+        run: npm run build -w example-fastify-api

--- a/examples/example-fastify-api/package.json
+++ b/examples/example-fastify-api/package.json
@@ -4,7 +4,8 @@
     "description": "",
     "type": "module",
     "scripts": {
-        "start": "tsx src/index.ts --project tsconfig.json"
+        "start": "tsx src/index.ts --project tsconfig.json",
+        "build": "tsc --project tsconfig.json"
     },
     "devDependencies": {
         "ts-node": "^10.9.2",


### PR DESCRIPTION
## Description

Adds a **Build and Test Examples** GitHub Actions workflow (`.github/workflows/examples.yml`) that builds each example on PRs, pushes to `main`, and merge queue entries.

Jobs (one per example):
- **Web App** — builds `example-fastify-web` (after building `@auth0/auth0-fastify`).
- **API** — builds `example-fastify-api` (after building `@auth0/auth0-fastify-api`).

Each example imports its SDK from the built `dist`, so the workflow builds the SDK before the example.

### Supporting change
- Added a `build` script to `example-fastify-api` (it only had `start`) so the workflow can verify it compiles, consistent with `example-fastify-web`.