### PR TITLE
ci: drop early-access branch trigger from workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,9 @@ on:
   merge_group:
   workflow_dispatch:
   pull_request:
-    branches: [main, early-access]
+    branches: [main]
   push:
-    branches: [main, early-access]
+    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Description

Removes the `early-access` branch from the `pull_request` and `push` triggers of the existing **Build and Test** workflow (`.github/workflows/test.yml`), so it runs only on `main` (plus `merge_group` and `workflow_dispatch`, unchanged).